### PR TITLE
fix: use keyword arguments in .create() instead of dict

### DIFF
--- a/modules/ai/openaiConnections.py
+++ b/modules/ai/openaiConnections.py
@@ -165,8 +165,9 @@ def ai_completion(client: OpenAI, messages: list[dict], response_format: dict = 
     if response_format and llm_spec in ["openai", "openai-like"]:
         params["response_format"] = response_format
 
-    completion = client.chat.completions.create(params)
-
+    ##> ------ Kyxie : kyriexie@outlook.com - Bug fix ------
+    completion = client.chat.completions.create(**params)
+    ##<
     result = ""
     
     # Log response


### PR DESCRIPTION
![Screenshot 2025-04-10 124602](https://github.com/user-attachments/assets/aff89085-8dde-4c68-8347-29e6ec6b1b2f)

I came across this issue while working with the code — `.create(params)`. This commit changes it to `.create(**params)`, which I think should fix the problem.