### PR TITLE
Pull Request: Simplify Config and Add Ollama Support

### DIFF
--- a/config/secrets.py
+++ b/config/secrets.py
@@ -23,10 +23,11 @@ password = "example_password"           # Enter your password in the quotes
 
 ## Artificial Intelligence (Beta Not-Recommended)
 # Use AI
+##> ------ Tim Lor : tulxoro - Documentation ------
 use_AI = True                          # True or False, Note: True or False are case-sensitive
 '''
 Note: Set it as True only if you want to use AI, and If you either have a
-1. Local LLM model running on your local machine, with it's APIs exposed. Example softwares to achieve it are:
+1. Local LLM model running on your local machine, with it's APIs exposed. Note that only Ollama seems to be supported. Example softwares to achieve it are:
     a. Ollama - https://ollama.com/
     b. llama.cpp - https://github.com/ggerganov/llama.cpp
     c. LM Studio - https://lmstudio.ai/ (Recommended)
@@ -34,57 +35,51 @@ Note: Set it as True only if you want to use AI, and If you either have a
 2. OR you have a valid OpenAI API Key, and money to spare, and you don't mind spending it.
 CHECK THE OPENAI API PIRCES AT THEIR WEBSITE (https://openai.com/api/pricing/). 
 '''
+##<
 
 ##> ------ Yang Li : MARKYangL - Feature ------
+##> ------ Tim Lor : tulxoro - Cleanup & Documentation ------
+# REMOVED: unnecessary extra variables for DeepSeek models (use llm instead)
+
 # Select AI Provider
-ai_provider = "deepseek"               # "openai", "deepseek"
+ai_provider = "openai"               # "openai", "deepseek"
 '''
 Note: Select your AI provider.
 * "openai" - OpenAI API (GPT models)
 * "deepseek" - DeepSeek API (DeepSeek models)
-'''
-
-# DeepSeek Configuration
-deepseek_api_url = "https://api.deepseek.com"       # Examples: "https://api.deepseek.com", "https://api.deepseek.com/v1"
-'''
-Note: DeepSeek API URL. 
-This URL is compatible with OpenAI interface. The full endpoint will be {deepseek_api_url}/chat/completions.
-'''
-
-deepseek_api_key = "YOUR_OPENAI_API_KEY"                # Enter your DeepSeek API key in the quotes
-'''
-Note: Enter your DeepSeek API key here. Leave it empty as "" or "not-needed" if not needed.
-'''
-
-deepseek_model = "deepseek-chat"     # Examples: "deepseek-chat", "deepseek-reasoner"
-'''
-Note: DeepSeek model selection
-* "deepseek-chat" - DeepSeek-V3, general conversation model
-* "deepseek-reasoner" - DeepSeek-R1, reasoning model
+* "ollama" - Ollama API (Ollama API)
 '''
 ##<
 
 # Your Local LLM url or other AI api url and port
-llm_api_url = "https://api.openai.com/v1/"       # Examples: "https://api.openai.com/v1/", "http://127.0.0.1:1234/v1/", "http://localhost:1234/v1/"
+llm_api_url = "http://localhost:11434"       # Examples: "https://api.openai.com/v1/", "http://127.0.0.1:1234/v1/", "http://localhost:1234/v1/"
 '''
-Note: Don't forget to add / at the end of your url
+Note: Don't forget to add / at the end of your url.
+If you are using deepseek, this URL is compatible with OpenAI interface. The full endpoint will be {deepseek_api_url}/chat/completions.
 '''
 
 # Your Local LLM API key or other AI API key 
-llm_api_key = "YOUR_OPENAI_API_KEY"              # Enter your API key in the quotes, make sure it's valid, if not will result in error.
+llm_api_key = ""              # Enter your API key in the quotes, make sure it's valid, if not will result in error.
 '''
 Note: Leave it empyt as "" or "not-needed" if not needed. Else will result in error!
 '''
 
 # Your local LLM model name or other AI model name
-llm_model = "gpt-3.5-turbo"          # Examples: "gpt-3.5-turbo", "gpt-4o", "llama-3.2-3b-instruct"
+llm_model = "deepseek-llm"          # Examples: "gpt-3.5-turbo", "gpt-4o", "llama-3.2-3b-instruct"
+'''
+Note: If using DeekSeek API, use DeepSeek's model selection
+* "deepseek-chat" - DeepSeek-V3, general conversation model
+* "deepseek-reasoner" - DeepSeek-R1, reasoning model
+'''
 
 
 #
 llm_spec = "openai"                # Examples: "openai", "openai-like", "openai-like-github", "openai-like-mistral"
 '''
 Note: Currently "openai" and "openai-like" api endpoints are supported.
+If you don't know what this means then just leave it as is.
 '''
+##<
 
 # # Yor local embedding model name or other AI Embedding model name
 # llm_embedding_model = "nomic-embed-text-v1.5"

--- a/config/secrets.py
+++ b/config/secrets.py
@@ -42,7 +42,7 @@ CHECK THE OPENAI API PIRCES AT THEIR WEBSITE (https://openai.com/api/pricing/).
 # REMOVED: unnecessary extra variables for DeepSeek models (use llm instead)
 
 # Select AI Provider
-ai_provider = "openai"               # "openai", "deepseek"
+ai_provider = ""               # "openai", "deepseek", "ollama"
 '''
 Note: Select your AI provider.
 * "openai" - OpenAI API (GPT models)
@@ -52,7 +52,7 @@ Note: Select your AI provider.
 ##<
 
 # Your Local LLM url or other AI api url and port
-llm_api_url = "http://localhost:11434"       # Examples: "https://api.openai.com/v1/", "http://127.0.0.1:1234/v1/", "http://localhost:1234/v1/"
+llm_api_url = ""       # Examples: "https://api.openai.com/v1/", "http://127.0.0.1:1234/v1/", "http://localhost:1234/v1/", "http://localhost:11434"
 '''
 Note: Don't forget to add / at the end of your url.
 If you are using deepseek, this URL is compatible with OpenAI interface. The full endpoint will be {deepseek_api_url}/chat/completions.
@@ -65,9 +65,9 @@ Note: Leave it empyt as "" or "not-needed" if not needed. Else will result in er
 '''
 
 # Your local LLM model name or other AI model name
-llm_model = "deepseek-llm"          # Examples: "gpt-3.5-turbo", "gpt-4o", "llama-3.2-3b-instruct"
+llm_model = ""          # Examples: "gpt-3.5-turbo", "gpt-4o", "llama-3.2-3b-instruct"
 '''
-Note: If using DeekSeek API, use DeepSeek's model selection
+Note: If using DeekSeek API, use DeepSeek's model selection. If you are using Ollama, ensure that you have pulled your desired model first.
 * "deepseek-chat" - DeepSeek-V3, general conversation model
 * "deepseek-reasoner" - DeepSeek-R1, reasoning model
 '''

--- a/modules/ai/deepseekConnections.py
+++ b/modules/ai/deepseekConnections.py
@@ -20,18 +20,21 @@ def deepseek_create_client() -> OpenAI | None:
         if not use_AI:
             raise ValueError("AI is not enabled! Please enable it by setting `use_AI = True` in `secrets.py` in `config` folder.")
         
-        
-        base_url = deepseek_api_url
+        ##> ------ Tim Lor : tulxoro - Refactor ------
+        base_url = llm_api_url
+        ##<
         
         if base_url.endswith('/'):
             base_url = base_url[:-1]
         
         # Create client with DeepSeek endpoint
-        client = OpenAI(base_url=base_url, api_key=deepseek_api_key)
+        ##> ------ Tim Lor : tulxoro - Refactor ------
+        client = OpenAI(base_url=base_url, api_key=llm_api_key)
+        ##<
         
         print_lg("---- SUCCESSFULLY CREATED DEEPSEEK CLIENT! ----")
         print_lg(f"Using API URL: {base_url}")
-        print_lg(f"Using Model: {deepseek_model}")
+        print_lg(f"Using Model: {llm_model}")
         print_lg("Check './config/secrets.py' for more details.\n")
         print_lg("---------------------------------------------")
         
@@ -69,14 +72,14 @@ def deepseek_completion(client: OpenAI, messages: list[dict], response_format: d
 
     # Set up parameters for the API call
     params = {
-        "model": deepseek_model, 
+        "model": llm_model, 
         "messages": messages, 
         "stream": stream,
         "timeout": 30  
     }
     
     # Add temperature if supported
-    if deepseek_model_supports_temperature(deepseek_model):
+    if deepseek_model_supports_temperature(llm_model):
         params["temperature"] = temperature
     
     # Add response format if needed (DeepSeek uses OpenAI-compatible API)
@@ -86,7 +89,7 @@ def deepseek_completion(client: OpenAI, messages: list[dict], response_format: d
     try:
         # Make the API call
         print_lg(f"Calling DeepSeek API for completion...")
-        print_lg(f"Using model: {deepseek_model}")
+        print_lg(f"Using model: {llm_model}")
         print_lg(f"Message count: {len(messages)}")
         completion = client.chat.completions.create(**params)
 

--- a/modules/ai/ollamaConnections.py
+++ b/modules/ai/ollamaConnections.py
@@ -1,0 +1,229 @@
+##> ------ Tim Lor : tulxoro - Feature ------
+import requests
+import json
+from config.secrets import *
+from config.settings import showAiErrorAlerts
+from modules.helpers import print_lg, critical_error_log, convert_to_json
+from modules.ai.prompts import *
+
+from typing import Literal, Union, Optional
+
+def ollama_create_client():
+    '''
+    Creates an Ollama client using the native Ollama API.
+    * Returns a client object configured for Ollama
+    '''
+    try:
+        print_lg("Creating Ollama client...")
+        if not use_AI:
+            raise ValueError("AI is not enabled! Please enable it by setting `use_AI = True` in `secrets.py` in `config` folder.")
+        
+        base_url = llm_api_url
+        
+        if base_url.endswith('/'):
+            base_url = base_url[:-1]
+        
+        # Test connection to Ollama
+        try:
+            response = requests.get(f"{base_url}/api/tags", timeout=10)
+            if response.status_code != 200:
+                raise ValueError(f"Ollama server not responding properly. Status: {response.status_code}")
+        except requests.exceptions.RequestException as e:
+            raise ValueError(f"Cannot connect to Ollama server at {base_url}. Make sure Ollama is running.")
+        
+        print_lg("---- SUCCESSFULLY CREATED OLLAMA CLIENT! ----")
+        print_lg(f"Using API URL: {base_url}")
+        print_lg(f"Using Model: {llm_model}")
+        print_lg("Check './config/secrets.py' for more details.\n")
+        print_lg("---------------------------------------------")
+        
+        return {"base_url": base_url, "model": llm_model}
+    except Exception as e:
+        error_message = f"Error occurred while creating Ollama client. Make sure your API connection details are correct."
+        critical_error_log(error_message, e)
+        if showAiErrorAlerts:
+            print_lg(f"{error_message}\n{str(e)}")
+        return None
+
+def ollama_completion(client, messages: list[dict], response_format: Optional[dict] = None, temperature: float = 0, stream: bool = stream_output) -> Union[str, dict]:
+    '''
+    Completes a chat using Ollama API and formats the results.
+    * Takes in `client` - The Ollama client
+    * Takes in `messages` of type `list[dict]` - The conversation messages
+    * Takes in `response_format` of type `dict` for JSON representation (optional)
+    * Takes in `temperature` of type `float` for randomness control (default 0)
+    * Takes in `stream` of type `bool` for streaming output (optional)
+    * Returns the response as text or JSON
+    '''
+    if not client: 
+        raise ValueError("Ollama client is not available!")
+
+    # Convert OpenAI format messages to Ollama format
+    prompt = ""
+    for message in messages:
+        if message["role"] == "user":
+            prompt += message["content"] + "\n"
+        elif message["role"] == "assistant":
+            prompt += "Assistant: " + message["content"] + "\n"
+        elif message["role"] == "system":
+            prompt = message["content"] + "\n\n" + prompt
+
+    # Set up parameters for the API call
+    params = {
+        "model": client["model"],
+        "prompt": prompt,
+        "stream": stream,
+        "options": {
+            "temperature": temperature if temperature > 0 else 0.1
+        }
+    }
+
+    try:
+        # Make the API call
+        print_lg(f"Calling Ollama API for completion...")
+        print_lg(f"Using model: {client['model']}")
+        print_lg(f"Message count: {len(messages)}")
+        
+        response = requests.post(
+            f"{client['base_url']}/api/generate",
+            json=params,
+            timeout=60,
+            stream=stream
+        )
+
+        if response.status_code != 200:
+            raise ValueError(f"Ollama API error: {response.status_code} - {response.text}")
+
+        result = ""
+        
+        # Process the response
+        if stream:
+            print_lg("--STREAMING STARTED")
+            for line in response.iter_lines():
+                if line:
+                    data = json.loads(line)
+                    if "response" in data:
+                        chunk = data["response"]
+                        result += chunk
+                        print_lg(chunk, end="", flush=True)
+                    if data.get("done", False):
+                        break
+            print_lg("\n--STREAMING COMPLETE")
+        else:
+            data = response.json()
+            result = data.get("response", "")
+        
+        # Convert to JSON if needed
+        if response_format:
+            result = convert_to_json(result)
+        
+        print_lg("\nOllama Answer:\n")
+        print_lg(result, pretty=response_format is not None)
+        return result
+    except Exception as e:
+        error_message = f"Ollama API error: {str(e)}"
+        print_lg(f"Full error details: {e.__class__.__name__}: {str(e)}")
+        
+        # If it's a connection or authentication error, provide more specific guidance
+        if "Connection" in str(e):
+            print_lg("This might be a network issue. Please check your internet connection.")
+            print_lg("Make sure Ollama is running on your local machine.")
+            print_lg("You can start Ollama by running 'ollama serve' in your terminal.")
+        elif "404" in str(e):
+            print_lg("The requested resource could not be found. The API URL or model name might be incorrect.")
+            print_lg("Make sure the model is pulled in Ollama. Run 'ollama pull qwen3' to download the model.")
+        elif "500" in str(e):
+            print_lg("Internal server error. The model might not be loaded properly.")
+            print_lg("Try restarting Ollama: 'ollama serve'")
+            
+        raise ValueError(error_message)
+
+def ollama_extract_skills(client, job_description: str, stream: bool = stream_output) -> dict:
+    '''
+    Function to extract skills from job description using Ollama API.
+    * Takes in `client` - The Ollama client
+    * Takes in `job_description` of type `str` - The job description text
+    * Takes in `stream` of type `bool` to indicate if it's a streaming call
+    * Returns a `dict` object representing JSON response
+    '''
+    try:
+        print_lg("Extracting skills from job description using Ollama...")
+        
+        # Using optimized prompt for Ollama
+        prompt = extract_skills_prompt.format(job_description)
+        messages = [{"role": "user", "content": prompt}]
+        
+        # Call Ollama completion
+        result = ollama_completion(
+            client=client,
+            messages=messages,
+            stream=stream
+        )
+        
+        # Ensure the result is a dictionary
+        if isinstance(result, str):
+            result = convert_to_json(result)
+            
+        return result
+    except Exception as e:
+        critical_error_log("Error occurred while extracting skills with Ollama!", e)
+        return {"error": str(e)}
+
+def ollama_answer_question(
+    client, 
+    question: str, options: Optional[list[str]] = None, 
+    question_type: Literal['text', 'textarea', 'single_select', 'multiple_select'] = 'text', 
+    job_description: Optional[str] = None, about_company: Optional[str] = None, user_information_all: Optional[str] = None,
+    stream: bool = stream_output
+) -> Union[str, dict]:
+    '''
+    Function to answer a question using Ollama AI.
+    * Takes in `client` - The Ollama client
+    * Takes in `question` of type `str` - The question to answer
+    * Takes in `options` of type `list[str] | None` - Options for select questions
+    * Takes in `question_type` - Type of question (text, textarea, single_select, multiple_select)
+    * Takes in optional context parameters - job_description, about_company, user_information_all
+    * Takes in `stream` of type `bool` - Whether to stream the output
+    * Returns the AI's answer
+    '''
+    try:
+        print_lg(f"Answering question using Ollama AI: {question}")
+        
+        # Prepare user information
+        user_info = user_information_all or ""
+        
+        # Prepare prompt based on question type
+        prompt = ai_answer_prompt.format(user_info, question)
+        
+        # Add options to the prompt if available
+        if options and (question_type in ['single_select', 'multiple_select']):
+            options_str = "OPTIONS:\n" + "\n".join([f"- {option}" for option in options])
+            prompt += f"\n\n{options_str}"
+            
+            if question_type == 'single_select':
+                prompt += "\n\nPlease select exactly ONE option from the list above."
+            else:
+                prompt += "\n\nYou may select MULTIPLE options from the list above if appropriate."
+        
+        # Add job details for context if available
+        if job_description:
+            prompt += f"\n\nJOB DESCRIPTION:\n{job_description}"
+        
+        if about_company:
+            prompt += f"\n\nABOUT COMPANY:\n{about_company}"
+        
+        messages = [{"role": "user", "content": prompt}]
+        
+        # Call Ollama completion
+        result = ollama_completion(
+            client=client,
+            messages=messages,
+            temperature=0.1,  # Slight randomness for more natural responses
+            stream=stream
+        )
+        
+        return result
+    except Exception as e:
+        critical_error_log("Error occurred while answering question with Ollama!", e)
+        return {"error": str(e)} 
+##<

--- a/modules/ai/prompts.py
+++ b/modules/ai/prompts.py
@@ -109,21 +109,21 @@ Response schema for `extract_skills` function
 ##> ------ Dheeraj Deshwal : dheeraj9811 Email:dheeraj20194@iiitd.ac.in/dheerajdeshwal9811@gmail.com - Feature ------
 ##> Answer Questions
 # Structure of messages = `[{"role": "user", "content": answer_questions_prompt}]`
-
+##> ------ Tim Lor : tulxoro - feature ------
 ai_answer_prompt = """
-You are an intelligent AI assistant filling out a form and answer like human,. 
-Respond concisely based on the type of question:
+You are a job applicant, not an AI assistant. Answer the following question as yourself. Do not mention that you are an AI, assistant, or language model. Do not include any introductory phrases or explanations. Respond concisely based on the type of question:
 
-1. If the question asks for **years of experience, duration, or numeric value**, return **only a number** (e.g., "2", "5", "10").
-2. If the question is **a Yes/No question**, return **only "Yes" or "No"**.
-3. If the question requires a **short description**, give a **single-sentence response**.
-4. If the question requires a **detailed response**, provide a **well-structured and human-like answer and keep no of character <350 for answering**.
-5. Do **not** repeat the question in your answer.
-6. here is user information to answer the questions if needed:
+1. If the question asks for years of experience, duration, or numeric value, return only the number (e.g., "5") with no extra words.
+2. If the question is a Yes/No question, return only "Yes" or "No" with no extra words.
+3. If the question requires a short description, answer in a single sentence, no more than 20 words.
+4. If the question requires a detailed response, answer in under 350 characters, focusing on the most important points.
+5. Do not repeat the question in your answer.
+6. Here is your user information to answer the questions if needed:
 **User Information:** 
 {}
 
-**QUESTION Strat from here:**  
+**QUESTION Start from here:**  
 {}
 """
+##<
 #<

--- a/modules/validator.py
+++ b/modules/validator.py
@@ -160,18 +160,22 @@ def validate_secrets() -> None | ValueError | TypeError:
     check_string(password, "password", min_length=5)
 
     check_boolean(use_AI, "use_AI")
+    ##> ------ Tim Lor : tulxoro - feature ------
     check_string(llm_api_url, "llm_api_url", min_length=5)
     check_string(llm_api_key, "llm_api_key")
-    check_string(llm_model, "llm_model")
     # check_string(llm_embedding_model, "llm_embedding_model")
     check_boolean(stream_output, "stream_output")
     
     ##> ------ Yang Li : MARKYangL - Feature ------
-    # Validate DeepSeek configuration
-    check_string(ai_provider, "ai_provider", ["openai", "deepseek"])
-    check_string(deepseek_api_url, "deepseek_api_url", min_length=5)
-    check_string(deepseek_api_key, "deepseek_api_key")
-    check_string(deepseek_model, "deepseek_model", ["deepseek-chat", "deepseek-reasoner"])
+    # validate supported ai providers
+    check_string(ai_provider, "ai_provider", ["openai", "deepseek", "ollama"])
+    # Only validate DeepSeek configuration if the ai_provider is actually DeepSeek
+    if ai_provider == "deepseek":
+        check_string(llm_model, "llm_model", ["deepseek-chat", "deepseek-reasoner"])
+    else:
+        # Otherwise, just make sure it is a string
+        check_string(llm_model, "llm_model")
+    ##<
     ##<
 
 

--- a/runAiBot.py
+++ b/runAiBot.py
@@ -41,6 +41,9 @@ from modules.clickers_and_finders import *
 from modules.validator import validate_config
 from modules.ai.openaiConnections import ai_create_openai_client, ai_extract_skills, ai_answer_question, ai_close_openai_client
 from modules.ai.deepseekConnections import deepseek_create_client, deepseek_extract_skills, deepseek_answer_question
+##> ------ Tim Lor : tulxoro - feature ------
+from modules.ai.ollamaConnections import ollama_create_client, ollama_extract_skills, ollama_answer_question
+##<
 
 from typing import Literal
 
@@ -632,6 +635,10 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
                                 answer = ai_answer_question(aiClient, label_org, question_type="text", job_description=job_description, user_information_all=user_information_all)
                             elif ai_provider.lower() == "deepseek":
                                 answer = deepseek_answer_question(aiClient, label_org, options=None, question_type="text", job_description=job_description, about_company=None, user_information_all=user_information_all)
+                            ##> ------ Tim Lor : tulxoro - Feature ------
+                            elif ai_provider.lower() == "ollama":
+                                answer = ollama_answer_question(aiClient, label_org, options=None, question_type="text", job_description=job_description, about_company=None, user_information_all=user_information_all)
+                            ##<
                             else:
                                 randomly_answered_questions.add((label_org, "text"))
                                 answer = years_of_experience
@@ -676,6 +683,10 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
                                 answer = ai_answer_question(aiClient, label_org, question_type="textarea", job_description=job_description, user_information_all=user_information_all)
                             elif ai_provider.lower() == "deepseek":
                                 answer = deepseek_answer_question(aiClient, label_org, options=None, question_type="textarea", job_description=job_description, about_company=None, user_information_all=user_information_all)
+                            ##> ------ Tim Lor : tulxoro - Feature ------
+                            elif ai_provider.lower() == "ollama":
+                                answer = ollama_answer_question(aiClient, label_org, options=None, question_type="textarea", job_description=job_description, about_company=None, user_information_all=user_information_all)
+                            ##<
                             else:
                                 randomly_answered_questions.add((label_org, "textarea"))
                                 answer = ""
@@ -971,6 +982,10 @@ def apply_to_jobs(search_terms: list[str]) -> None:
                                 skills = ai_extract_skills(aiClient, description)
                             elif ai_provider.lower() == "deepseek":
                                 skills = deepseek_extract_skills(aiClient, description)
+                            ##> ------ Tim Lor : tulxoro - Feature ------
+                            elif ai_provider.lower() == "ollama":
+                                skills = ollama_extract_skills(aiClient, description)
+                            ##<
                             else:
                                 skills = "In Development"
                             print_lg(f"Extracted skills using {ai_provider} AI")
@@ -1142,6 +1157,10 @@ def main() -> None:
                 aiClient = ai_create_openai_client()
             elif ai_provider.lower() == "deepseek":
                 aiClient = deepseek_create_client()
+            ##> ------ Tim Lor : tulxoro - Feature ------
+            elif ai_provider.lower() == "ollama":
+                aiClient = ollama_create_client()
+            ##<
             else:
                 print_lg(f"Unknown AI provider: {ai_provider}. Supported providers are: openai, deepseek")
                 aiClient = None
@@ -1204,7 +1223,7 @@ def main() -> None:
                 if ai_provider.lower() == "openai":
                     ai_close_openai_client(aiClient)
                 elif ai_provider.lower() == "deepseek":
-                    ai_close_openai_client(aiClient)  
+                    ai_close_openai_client(aiClient)
                 print_lg(f"Closed {ai_provider} AI client.")
             except Exception as e:
                 print_lg("Failed to close AI client:", e)


### PR DESCRIPTION
# Pull Request: Simplify Config and Add Ollama Support

## Description

The goal of this PR is to do the following:

- Make it easier for new users to configure the application for themselves by removing unnecessary variables related to deepseek (and reuse existing variables where it makes sense).
- Allow the use of Ollama for users who do not want to pay for an API usage.

## Changes

I made several changes to `/config/secrets.py`. The first thing being the removal of deepseek specific variables. The variables are unnecessary and bloat the config file. I made the deepseek implementation reuse existing variables for llms (which I assume was their primary purpose). For example, `deepseek-api-key` becomes the existing `llm-api-key` because they can be used roughly the same way. This also required me to modify `modules/ai/validator.py`. Besides this refactor, deepseek should operate the same way. I've also made the default options in `/config/secrets.py` blank by default.

I also implemented the usage of Ollama, for users that can host llms on their own machines. I created one new file, `modules/ai/ollamaConnections.py` to follow the existing pattern of other LLM integrations.

I also noticed that the prompts may lead the LLM to answer questions in a way similar to "As an AI....", so I modified the prompt to hopefully reduce this behavior.

## Testing

I have tested the Ollama integration separately. My changes should not have affected any other part of the application, and from my testing, everything seems fine. Because I do not have an API key for OpenAI or DeepSeek, I was unable to test them properly, but they should work fine regardless.