### PR TITLE
Pull Request: Add other LLM support without the user needing to dig through the code to change a couple of lines.

### DIFF
--- a/config/secrets.py
+++ b/config/secrets.py
@@ -44,32 +44,14 @@ Note: Select your AI provider.
 * "deepseek" - DeepSeek API (DeepSeek models)
 '''
 
-# DeepSeek Configuration
-deepseek_api_url = "https://api.deepseek.com"       # Examples: "https://api.deepseek.com", "https://api.deepseek.com/v1"
-'''
-Note: DeepSeek API URL. 
-This URL is compatible with OpenAI interface. The full endpoint will be {deepseek_api_url}/chat/completions.
-'''
-
-deepseek_api_key = "YOUR_OPENAI_API_KEY"                # Enter your DeepSeek API key in the quotes
-'''
-Note: Enter your DeepSeek API key here. Leave it empty as "" or "not-needed" if not needed.
-'''
-
-deepseek_model = "deepseek-chat"     # Examples: "deepseek-chat", "deepseek-reasoner"
-'''
-Note: DeepSeek model selection
-* "deepseek-chat" - DeepSeek-V3, general conversation model
-* "deepseek-reasoner" - DeepSeek-R1, reasoning model
-'''
-##<
+##> ------ Tim L : tulxoro - Refactor ------
 
 # Your Local LLM url or other AI api url and port
-llm_api_url = "https://api.openai.com/v1/"       # Examples: "https://api.openai.com/v1/", "http://127.0.0.1:1234/v1/", "http://localhost:1234/v1/"
+llm_api_url = "https://api.openai.com/v1/"       # Examples: "https://api.openai.com/v1/", "http://127.0.0.1:1234/v1/", "http://localhost:1234/v1/", "https://api.deepseek.com", "https://api.deepseek.com/v1"
 '''
 Note: Don't forget to add / at the end of your url
 '''
-
+##<
 # Your Local LLM API key or other AI API key 
 llm_api_key = "YOUR_OPENAI_API_KEY"              # Enter your API key in the quotes, make sure it's valid, if not will result in error.
 '''
@@ -84,8 +66,9 @@ llm_model = "gpt-3.5-turbo"          # Examples: "gpt-3.5-turbo", "gpt-4o", "lla
 llm_spec = "openai"                # Examples: "openai", "openai-like", "openai-like-github", "openai-like-mistral"
 '''
 Note: Currently "openai" and "openai-like" api endpoints are supported.
+If you aren't sure what this is, then you are safe to leave as.
 '''
-
+##<
 # # Yor local embedding model name or other AI Embedding model name
 # llm_embedding_model = "nomic-embed-text-v1.5"
 

--- a/config/secrets.py
+++ b/config/secrets.py
@@ -43,7 +43,7 @@ ai_provider = "openai"               # "openai", "deepseek"
 Note: Select your AI provider.
 * "openai" - OpenAI API (GPT models)
 * "deepseek" - DeepSeek API (DeepSeek models)
-* For any other models, keep it as "openai".
+* For any other models, keep it as "openai" if it is compatible with OpenAI's api.
 '''
 
 

--- a/config/secrets.py
+++ b/config/secrets.py
@@ -36,38 +36,42 @@ CHECK THE OPENAI API PIRCES AT THEIR WEBSITE (https://openai.com/api/pricing/).
 '''
 
 ##> ------ Yang Li : MARKYangL - Feature ------
+##> ------ Tim L : tulxoro - Refactor ------
 # Select AI Provider
-ai_provider = "deepseek"               # "openai", "deepseek"
+ai_provider = "openai"               # "openai", "deepseek"
 '''
 Note: Select your AI provider.
 * "openai" - OpenAI API (GPT models)
 * "deepseek" - DeepSeek API (DeepSeek models)
+* For any other models, keep it as "openai".
 '''
 
-##> ------ Tim L : tulxoro - Refactor ------
+
 
 # Your Local LLM url or other AI api url and port
-llm_api_url = "https://api.openai.com/v1/"       # Examples: "https://api.openai.com/v1/", "http://127.0.0.1:1234/v1/", "http://localhost:1234/v1/", "https://api.deepseek.com", "https://api.deepseek.com/v1"
+llm_api_url = "http://localhost:11434/v1/"       # Examples: "https://api.openai.com/v1/", "http://127.0.0.1:1234/v1/", "http://localhost:1234/v1/", "https://api.deepseek.com", "https://api.deepseek.com/v1"
 '''
 Note: Don't forget to add / at the end of your url
 '''
-##<
+
 # Your Local LLM API key or other AI API key 
-llm_api_key = "YOUR_OPENAI_API_KEY"              # Enter your API key in the quotes, make sure it's valid, if not will result in error.
+llm_api_key = "not-needed"              # Enter your API key in the quotes, make sure it's valid, if not will result in error.
 '''
-Note: Leave it empyt as "" or "not-needed" if not needed. Else will result in error!
+Note: Leave it empty as "" or "not-needed" if not needed. Else will result in error!
+If you are using ollama, you MUST put "not-needed" in there.
 '''
 
 # Your local LLM model name or other AI model name
-llm_model = "gpt-3.5-turbo"          # Examples: "gpt-3.5-turbo", "gpt-4o", "llama-3.2-3b-instruct"
+llm_model = "deepseek-llm:latest"          # Examples: "gpt-3.5-turbo", "gpt-4o", "llama-3.2-3b-instruct", "qwen3:latest"
 
 
 #
-llm_spec = "openai"                # Examples: "openai", "openai-like", "openai-like-github", "openai-like-mistral"
+llm_spec = "openai-like"                # Examples: "openai", "openai-like", "openai-like-github", "openai-like-mistral"
 '''
 Note: Currently "openai" and "openai-like" api endpoints are supported.
-If you aren't sure what this is, then you are safe to leave as.
+Most LLMs are compatible with openai, so keeping it as "openai-like" will work.
 '''
+##<
 ##<
 # # Yor local embedding model name or other AI Embedding model name
 # llm_embedding_model = "nomic-embed-text-v1.5"

--- a/modules/ai/deepseekConnections.py
+++ b/modules/ai/deepseekConnections.py
@@ -20,21 +20,22 @@ def deepseek_create_client() -> OpenAI | None:
         if not use_AI:
             raise ValueError("AI is not enabled! Please enable it by setting `use_AI = True` in `secrets.py` in `config` folder.")
         
+        ##> ------ Tim L : tulxoro - Refactor ------
+        base_url = llm_api_url
         
-        base_url = deepseek_api_url
-        
+
         if base_url.endswith('/'):
             base_url = base_url[:-1]
         
         # Create client with DeepSeek endpoint
-        client = OpenAI(base_url=base_url, api_key=deepseek_api_key)
+        client = OpenAI(base_url=base_url, api_key=llm_api_key)
         
         print_lg("---- SUCCESSFULLY CREATED DEEPSEEK CLIENT! ----")
         print_lg(f"Using API URL: {base_url}")
-        print_lg(f"Using Model: {deepseek_model}")
+        print_lg(f"Using Model: {llm_model}")
         print_lg("Check './config/secrets.py' for more details.\n")
         print_lg("---------------------------------------------")
-        
+        ##<
         return client
     except Exception as e:
         error_message = f"Error occurred while creating DeepSeek client. Make sure your API connection details are correct."
@@ -66,19 +67,21 @@ def deepseek_completion(client: OpenAI, messages: list[dict], response_format: d
     '''
     if not client: 
         raise ValueError("DeepSeek client is not available!")
-
+    ##> ------ Tim L : tulxoro - Improvement ------
     # Set up parameters for the API call
     params = {
-        "model": deepseek_model, 
+        
+        "model": llm_model, 
+   
         "messages": messages, 
         "stream": stream,
         "timeout": 30  
     }
     
     # Add temperature if supported
-    if deepseek_model_supports_temperature(deepseek_model):
+    if deepseek_model_supports_temperature(llm_model):
         params["temperature"] = temperature
-    
+
     # Add response format if needed (DeepSeek uses OpenAI-compatible API)
     if response_format:
         params["response_format"] = response_format
@@ -86,10 +89,10 @@ def deepseek_completion(client: OpenAI, messages: list[dict], response_format: d
     try:
         # Make the API call
         print_lg(f"Calling DeepSeek API for completion...")
-        print_lg(f"Using model: {deepseek_model}")
+        print_lg(f"Using model: {llm_model}")
         print_lg(f"Message count: {len(messages)}")
         completion = client.chat.completions.create(**params)
-
+    ##<
         result = ""
         
         # Process the response

--- a/modules/ai/openaiConnections.py
+++ b/modules/ai/openaiConnections.py
@@ -165,7 +165,12 @@ def ai_completion(client: OpenAI, messages: list[dict], response_format: dict = 
     if response_format and llm_spec in ["openai", "openai-like"]:
         params["response_format"] = response_format
 
-    completion = client.chat.completions.create(params)
+    ##> ------ Tim L : tulxoro - Feature ------
+    if llm_spec == "openai":
+        completion = client.chat.completions.create(params)
+    else:
+        completion = client.chat.completions.create(**params)
+    ##<
 
     result = ""
     

--- a/modules/validator.py
+++ b/modules/validator.py
@@ -162,16 +162,20 @@ def validate_secrets() -> None | ValueError | TypeError:
     check_boolean(use_AI, "use_AI")
     check_string(llm_api_url, "llm_api_url", min_length=5)
     check_string(llm_api_key, "llm_api_key")
-    check_string(llm_model, "llm_model")
     # check_string(llm_embedding_model, "llm_embedding_model")
     check_boolean(stream_output, "stream_output")
     
     ##> ------ Yang Li : MARKYangL - Feature ------
     # Validate DeepSeek configuration
     check_string(ai_provider, "ai_provider", ["openai", "deepseek"])
-    check_string(deepseek_api_url, "deepseek_api_url", min_length=5)
-    check_string(deepseek_api_key, "deepseek_api_key")
-    check_string(deepseek_model, "deepseek_model", ["deepseek-chat", "deepseek-reasoner"])
+
+    ##> ------ Tim L : tulxoro - Refactor ------
+    if ai_provider == "deepseek":
+        check_string(llm_model, "deepseek_model", ["deepseek-chat", "deepseek-reasoner"])
+    else:
+        check_string(llm_model, "llm_model")
+    ##<
+
     ##<
 
 


### PR DESCRIPTION
## Description

The goal of this PR is to do the following:

Make it easier for new users to configure the application for themselves by removing unnecessary variables related to deepseek (and reuse existing variables where it makes sense).
Allow the use of other LLMs compatible with OpenAI's API (such as Ollama).

## Changes

The DeepSeek-related variables are unnecessary and bloat the config file. I made the deepseek implementation reuse existing variables for llms (which I assume was their primary purpose). For example, `deepseek-api-key` becomes the existing `llm-api-key` because they can be used roughly the same way. This also required me to modify `modules/ai/validator.py`. Besides this refactor, deepseek should operate the same way.

I also suspect that with the current changes, there is no need to add other files for LLMs as long as **it is compatible with OpenAI's API** (i.e. DeepSeek, Ollama, Gemini).