### PR TITLE
Fix: raise CSV field size limit and add safe truncation for CSV writing

### DIFF
--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -224,3 +224,26 @@ def convert_to_json(data) -> dict:
         return result_json
     except json.JSONDecodeError:
         return {"error": "Unable to parse the response as JSON", "data": data}
+
+
+def truncate_for_csv(data, max_length: int = 131000, suffix: str = "...[TRUNCATED]") -> str:
+    '''
+    Function to truncate data for CSV writing to avoid field size limit errors.
+    * Takes in `data` of any type and converts to string
+    * Takes in `max_length` of type `int` - maximum allowed length (default: 131000, leaving room for suffix)
+    * Takes in `suffix` of type `str` - text to append when truncated
+    * Returns truncated string if data exceeds max_length
+    '''
+    try:
+        # Convert data to string
+        str_data = str(data) if data is not None else ""
+        
+        # If within limit, return as-is
+        if len(str_data) <= max_length:
+            return str_data
+        
+        # Truncate and add suffix
+        truncated = str_data[:max_length - len(suffix)] + suffix
+        return truncated
+    except Exception as e:
+        return f"[ERROR CONVERTING DATA: {e}]"

--- a/runAiBot.py
+++ b/runAiBot.py
@@ -19,6 +19,9 @@ import csv
 import re
 import pyautogui
 
+# Set CSV field size limit to prevent field size errors
+csv.field_size_limit(1000000)  # Set to 1MB instead of default 131KB
+
 from random import choice, shuffle, randint
 from datetime import datetime
 
@@ -793,7 +796,7 @@ def failed_job(job_id: str, job_link: str, resume: str, date_listed, error: str,
             fieldnames = ['Job ID', 'Job Link', 'Resume Tried', 'Date listed', 'Date Tried', 'Assumed Reason', 'Stack Trace', 'External Job link', 'Screenshot Name']
             writer = csv.DictWriter(file, fieldnames=fieldnames)
             if file.tell() == 0: writer.writeheader()
-            writer.writerow({'Job ID':job_id, 'Job Link':job_link, 'Resume Tried':resume, 'Date listed':date_listed, 'Date Tried':datetime.now(), 'Assumed Reason':error, 'Stack Trace':exception, 'External Job link':application_link, 'Screenshot Name':screenshot_name})
+            writer.writerow({'Job ID':truncate_for_csv(job_id), 'Job Link':truncate_for_csv(job_link), 'Resume Tried':truncate_for_csv(resume), 'Date listed':truncate_for_csv(date_listed), 'Date Tried':datetime.now(), 'Assumed Reason':truncate_for_csv(error), 'Stack Trace':truncate_for_csv(exception), 'External Job link':truncate_for_csv(application_link), 'Screenshot Name':truncate_for_csv(screenshot_name)})
             file.close()
     except Exception as e:
         print_lg("Failed to update failed jobs list!", e)
@@ -827,11 +830,11 @@ def submitted_jobs(job_id: str, title: str, company: str, work_location: str, wo
             fieldnames = ['Job ID', 'Title', 'Company', 'Work Location', 'Work Style', 'About Job', 'Experience required', 'Skills required', 'HR Name', 'HR Link', 'Resume', 'Re-posted', 'Date Posted', 'Date Applied', 'Job Link', 'External Job link', 'Questions Found', 'Connect Request']
             writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
             if csv_file.tell() == 0: writer.writeheader()
-            writer.writerow({'Job ID':job_id, 'Title':title, 'Company':company, 'Work Location':work_location, 'Work Style':work_style, 
-                            'About Job':description, 'Experience required': experience_required, 'Skills required':skills, 
-                                'HR Name':hr_name, 'HR Link':hr_link, 'Resume':resume, 'Re-posted':reposted, 
-                                'Date Posted':date_listed, 'Date Applied':date_applied, 'Job Link':job_link, 
-                                'External Job link':application_link, 'Questions Found':questions_list, 'Connect Request':connect_request})
+            writer.writerow({'Job ID':truncate_for_csv(job_id), 'Title':truncate_for_csv(title), 'Company':truncate_for_csv(company), 'Work Location':truncate_for_csv(work_location), 'Work Style':truncate_for_csv(work_style), 
+                            'About Job':truncate_for_csv(description), 'Experience required': truncate_for_csv(experience_required), 'Skills required':truncate_for_csv(skills), 
+                                'HR Name':truncate_for_csv(hr_name), 'HR Link':truncate_for_csv(hr_link), 'Resume':truncate_for_csv(resume), 'Re-posted':truncate_for_csv(reposted), 
+                                'Date Posted':truncate_for_csv(date_listed), 'Date Applied':truncate_for_csv(date_applied), 'Job Link':truncate_for_csv(job_link), 
+                                'External Job link':truncate_for_csv(application_link), 'Questions Found':truncate_for_csv(questions_list), 'Connect Request':truncate_for_csv(connect_request)})
         csv_file.close()
     except Exception as e:
         print_lg("Failed to update submitted jobs list!", e)


### PR DESCRIPTION
This PR fixes the "field larger than field limit (131072)" error in Python's CSV module.

**Root Cause:**
Python’s CSV module defaults to a max field size of 131,072 characters (128KB). Large job descriptions, AI-generated skill data, long stack traces, or question lists exceeded this limit, causing crashes when writing to CSV.

**Fix Implemented:**
1. Increased CSV field size limit from 131KB to 1MB in `runAiBot.py`.
2. Added a `truncate_for_csv()` helper in `helpers.py` to safely shorten oversized fields and append `...[TRUNCATED]`.
3. Updated CSV writing functions (`failed_job()` and `submitted_jobs()`) to apply truncation before writing.

**Result:**
- No more CSV crashes from large data fields.
- Large data is preserved up to limit, with clear truncation indicators.
- Future-proof against bigger data without breaking functionality.