### PR TITLE
fix: Add gemini to ai_provider validation and remove undefined do_actions in textarea handler

### DIFF
--- a/modules/validator.py
+++ b/modules/validator.py
@@ -168,8 +168,8 @@ def validate_secrets() -> None | ValueError | TypeError:
     check_boolean(stream_output, "stream_output")
     
     ##> ------ Yang Li : MARKYangL - Feature ------
-    # Validate DeepSeek configuration
-    check_string(ai_provider, "ai_provider", ["openai", "deepseek"])
+    # Validate DeepSeek and Gemini configuration
+    check_string(ai_provider, "ai_provider", ["openai", "deepseek", "gemini"])
 
     ##> ------ Tim L : tulxoro - Refactor ------
     if ai_provider == "deepseek":

--- a/runAiBot.py
+++ b/runAiBot.py
@@ -711,10 +711,6 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
                         randomly_answered_questions.add((label_org, "textarea"))
             text_area.clear()
             text_area.send_keys(answer)
-            if do_actions:
-                    sleep(2)
-                    actions.send_keys(Keys.ARROW_DOWN)
-                    actions.send_keys(Keys.ENTER).perform()
             questions_list.add((label, text_area.get_attribute("value"), "textarea", prev_answer))
             ##<
             continue


### PR DESCRIPTION


Bug 1: Validator rejects 'gemini' as valid ai_provider
- In modules/validator.py, check_string for ai_provider only allowed ['openai', 'deepseek']
- But the codebase fully supports 'gemini' (secrets.py, runAiBot.py, geminiConnections.py)
- Any user setting ai_provider='gemini' would get a ValueError on startup
- Fix: Added 'gemini' to the valid options list

Bug 2: do_actions variable undefined/leaked in textarea handler
- In runAiBot.py answer_questions(), the textarea handler referenced do_actions
- do_actions is only defined inside the text input handler (a different branch)
- If a textarea is the first question on a page -> NameError crash
- If preceded by a location text input with do_actions=True -> incorrect ARROW_DOWN+ENTER keyboard actions on the textarea field
- The do_actions logic (for location autocomplete dropdowns) is not applicable to textarea fields (summary, cover letter, etc.)
- Fix: Removed the misplaced do_actions block from the textarea handler