### PR TITLE
Bugfix/Validator only accepted "openai" and "deepseek", not "gemini"

### DIFF
--- a/modules/validator.py
+++ b/modules/validator.py
@@ -168,8 +168,8 @@ def validate_secrets() -> None | ValueError | TypeError:
     check_boolean(stream_output, "stream_output")
     
     ##> ------ Yang Li : MARKYangL - Feature ------
-    # Validate DeepSeek configuration
-    check_string(ai_provider, "ai_provider", ["openai", "deepseek"])
+    # Validate AI Provider configuration
+    check_string(ai_provider, "ai_provider", ["openai", "deepseek", "gemini"])
 
     ##> ------ Tim L : tulxoro - Refactor ------
     if ai_provider == "deepseek":


### PR DESCRIPTION
Error: Invalid input for ai_provider. Expecting a value from ['openai', 'deepseek'], not gemini!
Root Cause: Validator only accepted "openai" and "deepseek", not "gemini"
Fix Applied: Updated modules\validator.py line 172 to include "gemini"
Result: Gemini now fully supported