### PR TITLE
Load LinkedIn credentials from .env instead of hardcoding them in config/secrets.py

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+LINKEDIN_USERNAME=your_email@example.com
+LINKEDIN_PASSWORD=your_password

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ secrets.py
 config/personals.py
 .venv
 apikeys.py
+.env

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Click on above image to watch the tutorial for installation and configuration or
 1. [Python 3.10](https://www.python.org/) or above. Visit https://www.python.org/downloads/ to download and install Python, or for windows you could visit Microsoft Store and search for "Python". **Please make sure Python is added to Path in System Environment Variables**.
 2. Install necessary [Undetected Chromedriver](https://pypi.org/project/undetected-chromedriver/), [PyAutoGUI](https://pypi.org/project/PyAutoGUI/) and [Setuptools](https://pypi.org/project/setuptools/) packages. After Python is installed, OPEN a console/terminal or shell, Use below command that uses the [pip](https://pip.pypa.io/en/stable) command-line tool to install these 3 package.
   ```
-  pip install undetected-chromedriver pyautogui setuptools openai flask-cors flask
+  pip install undetected-chromedriver pyautogui setuptools openai flask-cors flask python-dotenv
   ```
 3. Download and install latest version of [Google Chrome](https://www.google.com/chrome) in it's default location, visit https://www.google.com/chrome to download it's installer.
 4. Clone the current git repo or download it as a zip file, url to the latest update https://github.com/GodsScion/Auto_job_applier_linkedIn.
@@ -50,7 +50,7 @@ Click on above image to watch the tutorial for installation and configuration or
 1. Open `personals.py` file in `/config` folder and enter your details like name, phone number, address, etc. Whatever you want to fill in your applications.
 2. Open `questions.py` file in `/config` folder and enter your answers for application questions, configure wether you want the bot to pause before submission or pause if it can't answer unknown questions.
 3. Open `search.py` file in `/config` folder and enter your search preferences, job filters, configure the bot as per your needs (these settings decide which jobs to apply for or skip).
-4. Open `secrets.py` file in `/config` folder and enter your LinkedIn username, password to login and OpenAI API Key for generation of job tailored resumes and cover letters (This entire step is optional). If you do not provide username or password or leave them as default, it will login with saved profile in browser, if failed will ask you to login manually.
+4. Copy `.env.example` to `.env` in the project root and fill in `LINKEDIN_USERNAME` and `LINKEDIN_PASSWORD`. These credentials are loaded by `config/secrets.py` at runtime and are kept out of git. This entire step is optional — if `.env` is missing or values are empty, the bot will log in with the saved browser profile, or ask you to log in manually if that fails. Open `secrets.py` in `/config` for any other (non-credential) settings such as your OpenAI API key.
 5. Open `settings.py` file in `/config` folder to configure the bot settings like, keep screen awake, click intervals (click intervals are randomized to seem like human behavior), run in background, stealth mode (to avoid bot detection), etc. as per your needs.
 6. (Optional) Don't forget to add you default resume in the location you mentioned in `default_resume_path = "all resumes/default/resume.pdf"` given in `/config/questions.py`. If one is not provided, it will use your previous resume submitted in LinkedIn or (In Development) generate custom resume if OpenAI APT key is provided!
 7. Run `runAiBot.py` and see the magic happen.

--- a/config/secrets.py
+++ b/config/secrets.py
@@ -19,8 +19,17 @@ version:    24.12.3.10.30
 
 
 # Login Credentials for LinkedIn (Optional)
-username = "username@example.com"       # Enter your username in the quotes
-password = "example_password"           # Enter your password in the quotes
+# Credentials are loaded from a local `.env` file. Copy `.env.example` to `.env` and fill in your details.
+# If `.env` is missing or the values are empty, the bot will fall back to a saved browser profile or manual login.
+import os
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+username = os.getenv("LINKEDIN_USERNAME", "")       # Set LINKEDIN_USERNAME in your .env file
+password = os.getenv("LINKEDIN_PASSWORD", "")       # Set LINKEDIN_PASSWORD in your .env file
 
 
 ## Artificial Intelligence (Beta Not-Recommended)


### PR DESCRIPTION
## Summary

`config/secrets.py` is tracked in the repo because it ships placeholder values and is imported everywhere. That makes it unsafe to put real LinkedIn credentials in — any `git add -A` or a distracted commit will push them to the user's fork. Adding `config/secrets.py` to `.gitignore` is not an option either, since the file is already tracked and needed by the app.

This PR introduces a minimal `.env`-based workflow for the two sensitive values (`username`, `password`) while keeping `config/secrets.py` tracked and backward-compatible.

## Changes

- **`config/secrets.py`** — replace the hardcoded `username` / `password` string literals with `os.getenv("LINKEDIN_USERNAME", "")` / `os.getenv("LINKEDIN_PASSWORD", "")`. `load_dotenv()` is imported inside a `try / except ImportError` block, so `python-dotenv` stays an optional dependency and users who don't install it still get a working file (env vars just have to be set another way, or left empty for the existing saved-profile / manual-login fallback).
- **`.env.example`** — new template with the two expected variables.
- **`.gitignore`** — add `.env` so real credentials never land in git.
- **`README.md`** — add `python-dotenv` to the `pip install` line in the install section, and rewrite config step 4 to describe the `.env` workflow (mentioning the fallback behavior when `.env` is absent).

## Backward compatibility

- No behavior change for users who already rely on the saved browser profile / manual login path — empty env vars produce empty strings, which matches the existing "leave them as default" flow documented in the old README step 4.
- `python-dotenv` is imported defensively; missing the package does not break the import of `config/secrets.py`.
- No other files are touched, so existing setups (settings, personals, questions, search, AI provider config) are unchanged.

## Test plan

- [ ] `pip install python-dotenv`, create `.env` with real values, run `runAiBot.py` — bot logs in with the env-provided credentials.
- [ ] Delete `.env` and run again — bot falls back to saved browser profile / manual login as before.
- [ ] Uninstall `python-dotenv` and import `config.secrets` — no `ImportError`; `username` / `password` resolve to whatever is already exported in the shell environment (or `""`).
- [ ] `git status` after adding real credentials to `.env` shows the file as ignored.