### PR TITLE
fix: make LinkedIn login resilient to form markup changes

### DIFF
--- a/modules/clickers_and_finders.py
+++ b/modules/clickers_and_finders.py
@@ -125,6 +125,77 @@ def text_input_by_ID(driver: WebDriver, id: str, value: str, time: float=5.0) ->
     username_field.send_keys(Keys.CONTROL + "a")
     username_field.send_keys(value)
 
+
+##> ------ Iliya Brook : iliyabrook1987@gmail.com - Bug fix ------
+# LinkedIn's login page uses React-generated IDs (`:r0:`, `:r1:`, ...) that
+# change on every render and renders multiple hidden copies of the same form.
+# Locating elements by `id`, `name` or brittle XPath text breaks on every
+# layout tweak. These helpers rely on the native `Element.checkVisibility()`
+# API (Chromium 105+, Firefox 125+, Safari 17.4+) to pick only the elements
+# the user actually sees, making the login flow resilient to markup churn.
+def find_visible_login_inputs(driver: WebDriver, time: float=10.0) -> tuple[WebElement, WebElement]:
+    '''
+    Find the visible username and password <input> elements of a login form.
+    - Uses the native Element.checkVisibility() API to ignore hidden duplicate
+      forms (LinkedIn renders several `<input>`s but only one pair is user-facing).
+    - Resilient to dynamic React-generated IDs and empty `name` attributes.
+    - Returns `(username_input, password_input)`.
+    - Raises `TimeoutError` if both fields don't appear within `time` seconds.
+    '''
+    script = (
+        "return Array.from(document.querySelectorAll('input')).filter("
+        "el => el.checkVisibility && el.checkVisibility("
+        "{opacityProperty: true, visibilityProperty: true}));"
+    )
+    import time as _time
+    deadline = _time.time() + time
+    while _time.time() < deadline:
+        userInput, passInput = None, None
+        for el in driver.execute_script(script) or []:
+            inputType = (el.get_attribute("type") or "").lower()
+            if inputType == "password" and passInput is None:
+                passInput = el
+            elif inputType in ("text", "email", "tel", "") and userInput is None:
+                userInput = el
+        if userInput is not None and passInput is not None:
+            return userInput, passInput
+        _time.sleep(0.2)
+    raise TimeoutError("Couldn't locate visible username/password inputs on the login form")
+
+
+def text_input_visible(driver: WebDriver, field: WebElement, value: str) -> None:
+    '''
+    Clears and types `value` into the already-located visible input `field`.
+    '''
+    field.send_keys(Keys.CONTROL + "a")
+    field.send_keys(value)
+
+
+def find_visible_buttons(driver: WebDriver, time: float=10.0) -> list[WebElement]:
+    '''
+    Return the list of *visible* buttons on the page, in DOM order.
+    - Scans `<button>`, `<input type="button">`, and `<input type="submit">`.
+    - Uses Element.checkVisibility() so hidden duplicate layouts are skipped.
+    - Waits up to `time` seconds for at least one visible button to appear.
+    - Raises `TimeoutError` if none show up in time.
+    '''
+    script = (
+        "return Array.from(document.querySelectorAll("
+        "'button, input[type=\"button\"], input[type=\"submit\"]'))"
+        ".filter(el => el.checkVisibility && el.checkVisibility("
+        "{opacityProperty: true, visibilityProperty: true}));"
+    )
+    import time as _time
+    deadline = _time.time() + time
+    while _time.time() < deadline:
+        buttons = driver.execute_script(script) or []
+        if buttons:
+            return buttons
+        _time.sleep(0.2)
+    raise TimeoutError("No visible buttons found on the page")
+##<
+
+
 def try_xp(driver: WebDriver, xpath: str, click: bool=True) -> WebElement | bool:
     try:
         if click:

--- a/runAiBot.py
+++ b/runAiBot.py
@@ -132,18 +132,20 @@ def login_LN() -> None:
         return
     try:
         wait.until(EC.presence_of_element_located((By.LINK_TEXT, "Forgot password?")))
-        try:
-            text_input_by_ID(driver, "username", username, 1)
-        except Exception as e:
-            print_lg("Couldn't find username field.")
-            # print_lg(e)
-        try:
-            text_input_by_ID(driver, "password", password, 1)
-        except Exception as e:
-            print_lg("Couldn't find password field.")
-            # print_lg(e)
-        # Find the login submit button and click it
-        driver.find_element(By.XPATH, '//button[@type="submit" and contains(text(), "Sign in")]').click()
+        ##> ------ Iliya Brook : iliyabrook1987@gmail.com - Bug fix ------
+        # LinkedIn no longer ships the login form with stable `id="username"` /
+        # `id="password"` attributes, and the primary Sign-in button is now a
+        # plain `<button type="button">` that shares its visible text with
+        # "Sign in with Apple". Rely on `Element.checkVisibility()` instead of
+        # XPath/ID selectors so the flow survives future markup changes.
+        userField, passField = find_visible_login_inputs(driver, 10)
+        text_input_visible(driver, userField, username)
+        text_input_visible(driver, passField, password)
+        # LinkedIn renders the primary action button last among visible buttons;
+        # clicking the final one avoids hitting "Sign in with Apple" or the
+        # "Show password" toggle.
+        find_visible_buttons(driver, 5)[-1].click()
+        ##<
     except Exception as e1:
         try:
             profile_button = find_by_class(driver, "profile__details")


### PR DESCRIPTION
## Problem

LinkedIn tweaks the `/login` page layout periodically, and every tweak used to break `login_LN()` in `runAiBot.py`. The function relied on three brittle anchors that no longer match the page:

1. **`text_input_by_ID(driver, "username", ...)` / `"password"`** — LinkedIn now renders the inputs with React-generated IDs (`:r0:`, `:r1:`, `:r2:`, …) that change on every render. Their `name` attribute is empty, so `By.NAME` would not save us either.
2. **Duplicate hidden forms** — the DOM contains ~6 `<input>` elements at once (a desktop copy and a mobile/secondary copy). Only one pair is actually visible to the user. A naive "first input of type text" picks the wrong, hidden one.
3. **`//button[@type="submit" and contains(text(), "Sign in")]`** — the primary action button has been downgraded to `<button type="button">` (no `type="submit"`), and the visible text `Sign in` is now shared with the **"Sign in with Apple"** social-login button that sits above it.

As a result, running the bot produces:
Couldn't find username field.
Couldn't find password field.
Couldn't Login!


and the only way to proceed is a manual log-in.

## Why the old selectors were fragile

Every selector the old code used (`id`, XPath with fixed class/text, `name`) is an **implementation detail** LinkedIn owns — they rename, reshuffle, and A/B-test these constantly. We cannot rely on them.

## Fix

Use the native [`Element.checkVisibility()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/checkVisibility) API (Chromium 105+, Firefox 125+, Safari 17.4+) to select only the elements the user actually sees. Visible user-facing elements are a much more stable contract than any specific attribute value.

Three small helpers are added to `modules/clickers_and_finders.py`:

- `find_visible_login_inputs(driver, timeout)` — runs `document.querySelectorAll('input')` in the page, filters by `checkVisibility({opacityProperty: true, visibilityProperty: true})`, and returns the one visible `text/email` input plus the one visible `password` input.
- `text_input_visible(driver, field, value)` — selects-all + types into an already-located `WebElement`.
- `find_visible_buttons(driver, timeout)` — generic helper returning visible `<button>` / `<input type="button"|"submit">` elements in DOM order.

`runAiBot.py::login_LN()` is rewritten to:

1. Locate the two visible inputs via `find_visible_login_inputs`.
2. Fill them with `text_input_visible`.
3. Click the **last** element returned by `find_visible_buttons(driver, 5)`. On the current login page the visible buttons are (in order) `Sign in with Apple`, `Show password`, `Sign in` — LinkedIn consistently renders the primary action last among visible buttons.

The outer `try / except` behavior (profile-button fallback, `manual_login_retry`, log lines) is preserved.

## Why this is more future-proof

- No dependency on generated `id` / `name` / `class` values.
- No dependency on exact XPath text, which also changes with locale and A/B tests.
- Works even if LinkedIn keeps injecting extra hidden form copies for responsive layouts.
- If LinkedIn ever reorders the visible buttons, the change is a one-line tweak (`[-1]` → different index) instead of rewriting selectors.

## Files changed

- `modules/clickers_and_finders.py` — three new helpers (`find_visible_login_inputs`, `text_input_visible`, `find_visible_buttons`). `text_input_by_ID` and the rest are untouched.
- `runAiBot.py` — only the inner block of `login_LN` that fills the form and clicks Sign in is replaced.

## Testing

Manually verified against `https://www.linkedin.com/login` on Chrome 147 (Linux) with `safe_mode = True` and `stealth_mode = False`:

- `find_visible_login_inputs` returns the two visible inputs (`type=text`, `type=password`) while skipping the 4 hidden duplicates.
- `find_visible_buttons(driver, 5)[-1]` lands on the correct `Sign in` button.
- Full auto-login succeeds and the bot proceeds to the feed.

No other code paths were touched, so existing flows (Easy Apply, external apply, question answering, etc.) remain unchanged.