### PR TITLE
Add Customer Success Manager automation (California or Remote)

### DIFF
--- a/config/search.py
+++ b/config/search.py
@@ -19,10 +19,10 @@ version:    26.01.20.5.08
 
 # These Sentences are Searched in LinkedIn
 # Enter your search terms inside '[ ]' with quotes ' "searching title" ' for each search followed by comma ', ' Eg: ["Software Engineer", "Software Developer", "Selenium Developer"]
-search_terms = ["Software Engineer", "Software Developer", "Python Developer", "Selenium Developer", "React Developer", "Java Developer", "Front End Developer", "Full Stack Developer", "Web Developer", "Nodejs Developer"]
+search_terms = ["Customer Success Manager", "CSM", "Customer Success"]
 
 # Search location, this will be filled in "City, state, or zip code" search box. If left empty as "", tool will not fill it.
-search_location = "United States"               # Some valid examples: "", "United States", "India", "Chicago, Illinois, United States", "90001, Los Angeles, California, United States", "Bengaluru, Karnataka, India", etc.
+search_location = ""               # Some valid examples: "", "United States", "India", "Chicago, Illinois, United States", "90001, Los Angeles, California, United States", "Bengaluru, Karnataka, India", etc.
 
 # After how many number of applications in current search should the bot switch to next search? 
 switch_number = 30                 # Only numbers greater than 0... Don't put in quotes
@@ -56,11 +56,11 @@ easy_apply_only = True             # True or False, Note: True or False are case
 
 experience_level = []              # (multiple select) "Internship", "Entry level", "Associate", "Mid-Senior level", "Director", "Executive"
 job_type = []                      # (multiple select) "Full-time", "Part-time", "Contract", "Temporary", "Volunteer", "Internship", "Other"
-on_site = []                       # (multiple select) "On-site", "Remote", "Hybrid"
+on_site = ["Remote"]                       # (multiple select) "On-site", "Remote", "Hybrid"
 
 companies = []                     # (dynamic multiple select) make sure the name you type in list exactly matches with the company name you're looking for, including capitals. 
                                    # Eg: "7-eleven", "Google","X, the moonshot factory","YouTube","CapitalG","Adometry (acquired by Google)","Meta","Apple","Byte Dance","Netflix", "Snowflake","Mineral.ai","Microsoft","JP Morgan","Barclays","Visa","American Express", "Snap Inc", "JPMorgan Chase & Co.", "Tata Consultancy Services", "Recruiting from Scratch", "Epic", and so on...
-location = []                      # (dynamic multiple select)
+location = ["California, United States"]                      # (dynamic multiple select)
 industry = []                      # (dynamic multiple select)
 job_function = []                  # (dynamic multiple select)
 job_titles = []                    # (dynamic multiple select)


### PR DESCRIPTION
## Overview
Configured the job application automation to specifically search for and apply to Customer Success Manager positions that are either based in California or remote.

## Changes Made
- **Search Terms**: Updated to focus on "Customer Success Manager", "CSM", and "Customer Success" roles
- **Job Location Filter**: Set to "Remote" to capture all remote positions
- **Geographic Filter**: Added "California, United States" to capture positions based in California
- **Search Location**: Cleared to allow LinkedIn's dynamic filters to handle location selection

## How It Works
The automation will now:
1. Search LinkedIn for CSM-related positions using the configured keywords
2. Filter results to include only "Remote" or "California" based jobs
3. Automatically apply to matching positions using the Easy Apply feature
4. Continue until reaching the configured application limit per search

## Configuration Details
- `search_terms`: ["Customer Success Manager", "CSM", "Customer Success"]
- `on_site`: ["Remote"]
- `location`: ["California, United States"]
- `easy_apply_only`: True (only applies to Easy Apply positions)
- `date_posted`: "Past week" (jobs posted in the past week)

## Testing
The configuration uses standard LinkedIn filter options and follows the existing automation framework. No new features were added—only configuration updates to target the specific job type and locations.