### PR TITLE
Add Contributor License Agreement and contributor-consent materials

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,334 @@
+# Individual Contributor License Agreement (CLA)
+
+> ## ⚠️ TEMPLATE — NOT LEGAL ADVICE
+>
+> **This document is a draft template only. It is NOT legal advice, and it has NOT
+> been reviewed by a lawyer.** Have a qualified lawyer (competent in Indian
+> copyright law and in the law of your contributors' home jurisdictions) review
+> and adapt this document **before** you use it or ask anyone to sign it. The
+> author of this template is not a lawyer. Nothing here is a substitute for
+> professional legal advice, and no certainty is expressed or implied about its
+> validity or enforceability in any jurisdiction.
+
+---
+
+## Plain-English summary (not the legal terms)
+
+This project — **Auto_job_applier_linkedIn** (the "Project") — is free and open
+source under the **GNU Affero General Public License v3.0 (AGPL-3.0)**, and it
+stays that way. This CLA does **not** take away the free, open-source version.
+
+When you contribute code, docs, or other material, this agreement asks you to
+grant **Sai Vignesh Golla, an individual** (the maintainer, referred to as "the
+Maintainer") a very broad, permanent permission to use your contribution — including
+the ability to include it in the AGPL-3.0 release **and** to release it under other
+licenses in the future, including proprietary/closed-source licenses. In plain
+terms, you let the Maintainer relicense the Project (or parts of it that include
+your contribution) however he chooses, while the AGPL-3.0 version remains available.
+
+In exchange:
+
+- You keep the right to use your own contribution however you like (your grant is
+  non-exclusive — you are not signing your work away exclusively).
+- The Project stays available under AGPL-3.0.
+- You confirm the work is really yours to give (or you have permission to give it),
+  and that, to your knowledge, it does not infringe anyone else's rights.
+
+You do **not** get paid for this, and the Maintainer is **not required** to use
+your contribution.
+
+If any of this matters to you, please get your own legal advice before signing.
+
+---
+
+## Operative terms
+
+**This Individual Contributor License Agreement ("Agreement") is entered into
+between:**
+
+- **You** — the individual identified in the acceptance block at the end of this
+  Agreement (or who accepts electronically as described in Section 11), referred to
+  as **"You"** or **"Contributor"**; and
+- **Sai Vignesh Golla, an individual** (GitHub: `GodsScion`), referred to as **"the
+  Maintainer."**
+
+The Maintainer accepts Contributions on his own behalf **as an individual**. This
+Agreement does not create any grant to, and does not run in favour of, any company,
+firm, partnership, or other entity.
+
+### 1. Definitions
+
+1.1. **"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that You intentionally submit to the
+Maintainer for inclusion in, or documentation of, the Project. "Submit" means any
+form of electronic, verbal, or written communication sent to the Maintainer or the
+Project, including but not limited to communication on source-code repositories,
+issue trackers, pull requests, and mailing lists, but excluding communication that
+You conspicuously mark or otherwise designate in writing as "Not a Contribution."
+
+1.2. **"Project"** means the software project maintained by the Maintainer and known
+as **Auto_job_applier_linkedIn** (repository:
+`https://github.com/GodsScion/Auto_job_applier_linkedIn`), and any successor,
+fork-of-record, or renamed version maintained by the Maintainer.
+
+1.3. **"Work"** means the collective software, documentation, and other materials
+comprising the Project.
+
+### 2. Copyright license (this Section stands on its own)
+
+2.1. Subject to the terms of this Agreement, You hereby grant to the Maintainer a
+license to Your Contribution that is:
+
+- **perpetual** (for the entire duration of copyright and any renewals or
+  extensions);
+- **irrevocable** (except as expressly stated in this Agreement);
+- **worldwide** (valid in every country and territory);
+- **royalty-free** and fully paid-up;
+- **non-exclusive**; and
+- **sublicensable and transferable.**
+
+2.2. This license expressly includes all rights comprised in copyright, including
+without limitation the rights to:
+
+- (a) reproduce the Contribution;
+- (b) prepare, create, and have created derivative works of the Contribution;
+- (c) publicly display and publicly perform the Contribution;
+- (d) distribute, publish, make available, and communicate the Contribution to the
+  public by any means now known or later developed;
+- (e) sublicense the foregoing rights through multiple tiers; and
+- (f) **relicense the Contribution — alone or as part of the Work — under ANY
+  license terms the Maintainer chooses, including permissive, copyleft, commercial,
+  and proprietary / closed-source terms**, without any obligation to keep the
+  Contribution under AGPL-3.0 in those separately-licensed distributions.
+
+2.3. **Duration and territory (stated expressly).** The license in this Section 2 is
+granted for the **entire term of copyright in the Contribution, worldwide**. The
+parties state this expressly and intend it to override any statutory default that
+would otherwise limit an unspecified license to a shorter term or to a single
+territory.
+
+> ⚠️ **LAWYER REVIEW — Indian Copyright Act.** Section 19(5) and 19(6) of the Indian
+> Copyright Act, 1957 provide that where a licence/assignment does not state a
+> duration or territorial extent, the term may default to **five (5) years** and the
+> territory to **India only** (see also §§ 19(3), 19A, and 30A applying § 19 to
+> licences). Section 2.3 is drafted to displace those defaults by stating term and
+> territory expressly. Confirm this drafting is sufficient under current law and
+> case law.
+
+2.4. This Section 2 is intended to be a valid, standalone **licence** grant that
+takes effect **independently** of the assignment in Section 3, including where the
+assignment in Section 3 is wholly or partly unenforceable, and including where this
+Agreement is accepted electronically.
+
+> ⚠️ **LAWYER REVIEW.** Section 30 of the Indian Copyright Act (as amended in 2012)
+> permits the owner of copyright to grant a **licence** in a future or existing work,
+> and licences are generally recognised as capable of being granted electronically.
+> This Agreement therefore leads with a licence (Section 2) so that a click-through /
+> electronic acceptance can be effective even if the written-signature formalities
+> required for an **assignment** (Section 19(1), below) are not met.
+
+### 3. Assignment (to the fullest extent permitted by law), with license fallback
+
+3.1. To the **fullest extent permitted by applicable law**, and to the extent an
+assignment (rather than a licence) is legally effective, You hereby **assign** to the
+Maintainer all right, title, and interest in and to the copyright in Your
+Contribution, worldwide and for the full term of copyright and any renewals,
+reversions, and extensions.
+
+3.2. **License fallback (severability of the grant).** To the extent that the
+assignment in Section 3.1 is invalid, unenforceable, ineffective, incomplete, or
+requires formalities that have not been satisfied — for any reason and in any
+jurisdiction — the assignment shall be treated as **not having been made** to that
+extent, and the **licence granted in Section 2 shall govern and shall remain in full
+force** with respect to the affected rights. The parties intend that the Maintainer
+receive, at minimum, the full licence in Section 2, whether or not any assignment
+takes effect.
+
+> ⚠️ **LAWYER REVIEW — Indian Copyright Act § 19(1).** An assignment of copyright in
+> India must be **in writing signed** by the assignor (or an authorised agent).
+> Electronic click-through acceptance may **not** satisfy this formality. Two
+> consequences to confirm with counsel: (a) the assignment in Section 3.1 may require
+> a separately **signed writing** (wet-ink or a qualifying e-signature) to be fully
+> effective; and (b) the license-fallback in Section 3.2 is drafted so that, even if
+> the assignment fails, the Maintainer still holds the broad licence in Section 2.
+> Confirm both the fallback mechanism and what signing method (if any) makes the
+> assignment enforceable for Indian and non-Indian contributors.
+
+3.3. **Further assurances.** Upon the Maintainer's reasonable request, You agree to
+sign and deliver any additional documents (including a separately signed written
+assignment) reasonably necessary to perfect, record, or give full effect to the
+assignment in Section 3.1. This obligation does not limit the licence in Section 2,
+which is effective without any further action.
+
+### 4. Patent license
+
+4.1. Subject to the terms of this Agreement, You hereby grant to the Maintainer and
+to recipients of software distributed by the Maintainer a **perpetual, worldwide,
+non-exclusive, royalty-free, irrevocable** (except as stated in this Section 4)
+patent license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Contribution and the Work, where such license applies only to those
+patent claims licensable by You that are necessarily infringed by Your Contribution
+alone or by combination of Your Contribution with the Work to which You submitted it.
+
+4.2. If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Work to which You contributed, constitutes direct or
+contributory patent infringement, then any patent licenses granted under this Section
+4 to that entity for that Contribution or Work shall terminate as of the date such
+litigation is filed. (This clause is modelled on the Apache-2.0 Individual CLA.)
+
+### 5. Your representations
+
+You represent and warrant that:
+
+5.1. Each of Your Contributions is **Your original creation**, or You otherwise have
+the legal right and authority to submit it and to grant the licenses and assignment
+in this Agreement.
+
+5.2. So far as You are aware, Your Contribution does **not knowingly infringe or
+misappropriate** any third party's copyright, patent, trademark, trade secret, or
+other intellectual-property or proprietary right.
+
+5.3. If Your Contribution includes or depends on third-party materials (for example,
+code under another open-source license), You have **identified** those materials and
+their license terms in a way the Maintainer can reasonably see (for example, in the
+pull request description or in the source), to the extent You are aware of them.
+
+5.4. If Your employer or any other person has rights to intellectual property that
+You create, You represent that You have **received permission** to make the
+Contribution on behalf of that party, that that party has waived such rights for the
+Contribution, or that that party has separately agreed in writing to this Agreement.
+
+5.5. Except for the representations in this Section 5, the Contribution is provided
+**"AS IS"** without warranties of any kind, to the extent permitted by law. You are
+not expected to provide support for Your Contribution.
+
+### 6. Rights You keep
+
+6.1. **You keep ownership of your other work.** Except for the licence granted in
+Section 2 and any assignment that takes effect under Section 3, nothing in this
+Agreement transfers any of Your other rights.
+
+6.2. **You keep the right to use your own Contribution.** You retain a
+**non-exclusive, perpetual, worldwide, royalty-free** right to use, reproduce, modify,
+distribute, and otherwise exploit **Your own Contribution** for any purpose,
+including in other projects. Where Section 3 operates as an assignment, the Maintainer
+hereby grants back to You this non-exclusive right so that You are never prevented
+from using Your own Contribution.
+
+### 7. Moral rights
+
+7.1. To the fullest extent permitted by applicable law, You agree not to assert
+against the Maintainer or downstream recipients any **moral rights** (such as the
+right of attribution or the right of integrity) in a manner that would prevent the
+Maintainer from exercising the rights granted under this Agreement, including
+relicensing and creating derivative works. Where moral rights cannot be waived or
+assigned, You **consent** to the acts contemplated by this Agreement to the extent
+the law allows.
+
+> ⚠️ **LAWYER REVIEW — moral rights.** Under Indian law (§ 57 of the Copyright Act)
+> and the law of several other countries, **moral rights are not assignable and may
+> not be fully waivable.** Confirm the correct treatment (waiver vs. consent vs.
+> silence) for Indian contributors and for contributors elsewhere.
+
+### 8. No obligation
+
+8.1. The Maintainer is under **no obligation** to accept, use, or distribute any
+Contribution, and may remove or modify any Contribution at any time.
+
+### 9. The Project stays open source (AGPL-3.0)
+
+9.1. This Agreement **does not withdraw, cancel, or diminish** the Project's
+availability under the **GNU Affero General Public License, version 3.0 (AGPL-3.0)**.
+The Project remains available to the public under AGPL-3.0.
+
+9.2. The rights granted in this Agreement are **in addition to** AGPL-3.0. They give
+the Maintainer the ability to **also** license the Work (or parts of it) under other
+terms (including proprietary terms), **without** removing or replacing the AGPL-3.0
+version already made available.
+
+### 10. Nature of the grant; relationship of Sections 2 and 3
+
+10.1. This Agreement is **primarily a licence** (Section 2), **plus** an assignment
+to the fullest extent permitted by law (Section 3) that falls back to the licence
+where the assignment does not take effect. If there is any conflict, the reading that
+**preserves the broadest grant to the Maintainer that is legally valid** shall
+prevail, subject always to the rights You keep under Section 6.
+
+### 11. Electronic acceptance
+
+11.1. You may accept this Agreement **electronically**, and the parties intend such
+acceptance to be **binding**, by either:
+
+- (a) confirming acceptance through an automated CLA tool (for example, the
+  CLA-assistant GitHub app) that records Your agreement against Your pull request; or
+- (b) posting the following statement as a comment on Your pull request from Your
+  own account:
+
+  > *"I have read and I agree to the Contributor License Agreement (CLA.md) of the
+  > Auto_job_applier_linkedIn project. I submit this Contribution under its terms."*
+
+11.2. Electronic acceptance under Section 11.1 is intended to grant and confirm the
+**licence in Section 2** (and Sections 4, 6, and 7), which the parties intend to be
+effective electronically.
+
+> ⚠️ **LAWYER REVIEW.** Section 30 of the Indian Copyright Act supports granting a
+> **licence** electronically, and India's Information Technology Act, 2000 recognises
+> electronic records and (certain) electronic signatures. However, the **assignment**
+> in Section 3 may require a **signed writing** under § 19(1) that a click-through
+> comment does not satisfy. Confirm: (a) that electronic acceptance validly grants the
+> Section 2 licence; and (b) what additional signing step, if any, is needed to make
+> the Section 3 assignment effective. Consider collecting a signed writing (e.g. a
+> qualifying e-signature) for the assignment where full copyright transfer is desired.
+
+### 12. Governing law and jurisdiction
+
+12.1. This Agreement is governed by the laws of **India**, without regard to its
+conflict-of-laws rules, and the parties submit to the courts having jurisdiction in
+India.
+
+> ⚠️ **LAWYER REVIEW.** Confirm the governing-law and jurisdiction choice, and whether
+> it is enforceable against contributors residing outside India. A different or
+> additional governing-law / dispute clause may be advisable for cross-border
+> contributors.
+
+### 13. Miscellaneous
+
+13.1. **Severability.** If any provision of this Agreement is held invalid or
+unenforceable, that provision shall be limited or severed to the minimum extent
+necessary, and the remaining provisions shall remain in full force. In particular,
+the invalidity of the assignment in Section 3 shall **not** affect the validity of
+the licence in Section 2 (see Section 3.2).
+
+13.2. **Entire agreement.** This Agreement is the entire agreement between the parties
+about its subject matter and supersedes prior discussions on that subject. It does
+not modify the AGPL-3.0 terms under which the Work is distributed to the public.
+
+13.3. **No waiver.** A failure to enforce any provision is not a waiver of it.
+
+13.4. **Successors.** This Agreement binds and benefits the parties and their
+respective heirs, successors, and permitted assigns. The Maintainer may assign this
+Agreement and the rights granted under it.
+
+---
+
+## Acceptance block
+
+> For electronic acceptance, see Section 11. The fields below are provided for cases
+> where a **signed writing** is used (recommended where the Section 3 assignment is
+> intended to take full effect — confirm with your lawyer).
+
+- **Contributor full name:** ________________________________________
+- **GitHub username:** ______________________________________________
+- **Email:** ________________________________________________________
+- **Country of residence:** _________________________________________
+- **Date (YYYY-MM-DD):** ____________________________________________
+- **Signature:** ____________________________________________________
+
+**Accepted on behalf of the Maintainer:** Sai Vignesh Golla, an individual (GitHub:
+`GodsScion`).
+
+---
+
+*Filename: `CLA.md`. This is a template pending lawyer review — see the disclaimer at
+the top of this file.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing
+
+Thanks for your interest in contributing to **Auto_job_applier_linkedIn**! All
+contributions are welcome, no matter how small or large.
+
+## 1. Sign the Contributor License Agreement (CLA)
+
+Before your contribution can be merged, you must agree to the project's
+**[Contributor License Agreement](CLA.md)**.
+
+- **How you sign:** When you open a pull request, an automated bot
+  ([CLA-assistant](https://cla-assistant.io/)) will comment with a link. Follow it
+  and confirm that you agree to [`CLA.md`](CLA.md). Your agreement is recorded against
+  your GitHub account. If the CLA changes later, you may be asked to agree again.
+- **What you are agreeing to (plain English):** you grant the maintainer, **Sai
+  Vignesh Golla (an individual)**, a broad, permanent license to your contribution —
+  including the right to relicense it (even under proprietary terms) — while the
+  project **stays free and open under AGPL-3.0**. You keep the right to use your own
+  contribution elsewhere. Please read [`CLA.md`](CLA.md) for the full terms and the
+  important "template — not legal advice" disclaimer.
+
+> If you have contributed **before** this CLA existed, thank you! We may reach out to
+> ask you to confirm the CLA applies to your already-merged work. See
+> [`docs/contributor-consent/`](docs/contributor-consent/).
+
+## 2. Follow the existing code guidelines
+
+This project already documents its code style, naming conventions, configuration-variable
+rules, and the **attestation format** for contributions. Please read and follow the
+**Contributor Guidelines** section of the [README](README.md#-contributor-guidelines)
+rather than duplicating it here. In particular:
+
+- **Code guidelines** — function naming/docstrings/type hints, variable naming, and
+  configuration-variable rules: see [README → Code Guidelines](README.md#code-guidelines).
+- **Attestation** — every contribution needs an attestation marker in the code, in the
+  form:
+
+  ```python
+  ##> ------ <Your full name> : <github id> OR <email> - <Type of change> ------
+      # your code
+  ##<
+  ```
+
+  See [README → Attestation](README.md) for full examples. Keeping accurate attestation
+  markers also helps us maintain the contributor records in
+  [`docs/contributor-consent/contributors.md`](docs/contributor-consent/contributors.md).
+
+## 3. Where to send pull requests
+
+Per the README, **pull requests should target the `community-version` branch**, not
+`main`. PRs to other branches (especially `main`) are declined by default. Once your
+change is tested, it is merged into `main` in the next cycle. See
+[README → Contributor Guidelines](README.md#-contributor-guidelines) for details.
+
+## 4. Quick checklist before opening a PR
+
+- [ ] My PR targets the `community-version` branch.
+- [ ] I followed the code and attestation guidelines in the [README](README.md#-contributor-guidelines).
+- [ ] I added an attestation marker for my change.
+- [ ] I have read and agreed to the [CLA](CLA.md) (the bot will prompt me).
+- [ ] My contribution is my own work, or I have the right to submit it.
+
+Thank you for helping improve the project!

--- a/docs/contributor-consent/cla-assistant-setup.md
+++ b/docs/contributor-consent/cla-assistant-setup.md
@@ -1,0 +1,129 @@
+# Setting up CLA-assistant for future pull requests
+
+> **Note:** This is a setup guide, not legal advice. The binding terms are in
+> [`../../CLA.md`](../../CLA.md), which should be reviewed by a lawyer before you rely
+> on it. This guide explains how to make new contributors accept that CLA
+> automatically when they open a pull request.
+
+## What CLA-assistant does
+
+[CLA-assistant](https://cla-assistant.io/) is a free, open-source tool (maintained by
+SAP) that:
+
+- Comments on every new pull request asking the contributor to agree to your CLA.
+- Records each contributor's agreement against their **GitHub account**.
+- Sets a PR **status check** that stays "pending"/failing until every commit author in
+  the PR has signed — so unsigned PRs are easy to spot and can be blocked from merging.
+- **Re-prompts** contributors to sign again when the CLA text changes (see step 6).
+
+There are two ways to run it. Pick one:
+
+- **Option A — Hosted app at `cla-assistant.io`** (fastest; the CLA text lives in a
+  GitHub Gist). Steps below.
+- **Option B — [CLA Assistant Lite](https://github.com/contributor-assistant/github-action)**
+  (a GitHub Action that runs entirely inside this repo; signatures are stored in a file
+  in your repo/branch). Good if you'd rather not grant a third-party service access.
+  Summary at the end.
+
+---
+
+## Option A — Hosted `cla-assistant.io` (recommended for speed)
+
+### Step 1 — Put the CLA text where CLA-assistant can read it (a Gist)
+
+The hosted service reads the CLA text from a **public GitHub Gist**.
+
+1. Go to <https://gist.github.com> (signed in as `GodsScion`).
+2. Create a **public** Gist. Name the file e.g. `CLA.md`.
+3. Paste the **contents of [`../../CLA.md`](../../CLA.md)** into it, and **Create public
+   gist**.
+4. Copy the Gist URL — you'll need it in Step 4.
+
+> Keep this Gist as the single source of truth that CLA-assistant shows contributors.
+> Whenever you change [`CLA.md`](../../CLA.md) in the repo, update this Gist too (Step 6).
+
+### Step 2 — Sign in to CLA-assistant
+
+1. Go to <https://cla-assistant.io/>.
+2. Click **Sign in with GitHub** and authorize the CLA-assistant OAuth app.
+   - It requests permission to set up a webhook and status checks and to comment on
+     PRs. Review the requested scopes before approving.
+
+### Step 3 — Configure a new CLA
+
+1. In the CLA-assistant dashboard, click **Configure CLA**.
+2. Choose scope: select the repository **`GodsScion/Auto_job_applier_linkedIn`**
+   (or configure it org-wide if you prefer it to cover all your repos).
+
+### Step 4 — Point it at your CLA Gist
+
+1. Paste the **Gist URL** from Step 1 as the CLA source.
+2. (Optional) Add **custom fields** you want contributors to fill in when signing (for
+   example: full name, email, country) — useful given the Indian-law signing questions
+   flagged in `CLA.md`.
+3. Save. CLA-assistant will install a **webhook** and a **status check** on the repo.
+
+### Step 5 — Require the check before merging
+
+1. In the repo: **Settings → Branches → Branch protection rules**.
+2. Add/edit a rule for the branch you merge contributions into
+   (**`community-version`**, and `main` if you want it there too).
+3. Enable **"Require status checks to pass before merging"** and select the
+   **CLA-assistant** check (e.g. `license/cla`).
+
+Now: when someone opens a PR, the bot comments with a sign link; once they click and
+agree, the check turns green and the PR becomes mergeable.
+
+### Step 6 — Re-prompting when the CLA changes
+
+CLA-assistant tracks the **revision** of the CLA source. When you meaningfully change
+the CLA:
+
+1. Update the **Gist** (edit it) so its content matches the new
+   [`CLA.md`](../../CLA.md) — this creates a new Gist revision.
+2. CLA-assistant will treat existing signatures as tied to the older revision, so
+   contributors are asked to **sign again** on their next PR.
+   - If needed, use the dashboard's **re-check / re-notify** controls to prompt
+     re-signing.
+
+> Keep [`CLA.md`](../../CLA.md), the Gist, and (if used) the Option-B signatures source
+> in sync so contributors always see the current terms.
+
+### Step 7 — Keep a link in the repo
+
+`CONTRIBUTING.md` already tells contributors the bot will ask them to sign the CLA.
+No extra change is needed, but double-check the link to [`CLA.md`](../../CLA.md) is
+correct after setup.
+
+---
+
+## Option B — CLA Assistant Lite (self-hosted GitHub Action)
+
+If you'd rather not grant a hosted service access, use the
+[CLA Assistant Lite](https://github.com/contributor-assistant/github-action) Action:
+
+1. Add a workflow (e.g. `.github/workflows/cla.yml`) using
+   `contributor-assistant/github-action`.
+2. Point `path-to-document` at your CLA (e.g. a link to `CLA.md` on the default branch)
+   and set `path-to-signatures` to a JSON file (often stored on a dedicated
+   `cla-signatures` branch).
+3. Contributors sign by commenting a configured phrase (e.g. *"I have read the CLA
+   Document and I hereby sign the CLA"*) on their PR; the Action records their GitHub
+   login and commit info in the signatures file.
+4. Configure it to require re-signing when the CLA changes (the Action supports
+   invalidating signatures when the document/version changes).
+5. Add the Action's check to branch protection as in Option A, Step 5.
+
+This keeps everything — CLA text and signature records — inside the repository under
+your control, at the cost of a little more setup.
+
+---
+
+## Notes and open questions for the lawyer
+
+- Confirm that **electronic acceptance via CLA-assistant** is sufficient for the
+  **license** grant in `CLA.md` (Section 2/11), and what, if anything, more is needed
+  to make the **assignment** (Section 3) effective — see the § 19(1) flag in `CLA.md`.
+- Decide whether to require the extra **custom fields** (name/email/country) at
+  signing time to strengthen the record.
+- Decide the policy for PRs from contributors who won't sign (typically: not merged).

--- a/docs/contributor-consent/contributors.md
+++ b/docs/contributor-consent/contributors.md
@@ -1,0 +1,87 @@
+# Past contributors to contact for retroactive CLA consent
+
+> ## ⚠️ TEMPLATE / WORKING DOCUMENT — NOT LEGAL ADVICE
+>
+> This list supports the effort to ask **past** contributors to confirm that the
+> project's [Contributor License Agreement](../../CLA.md) applies to their
+> already-merged contributions. It is a working record, not legal advice. Have a
+> lawyer confirm the approach before relying on any consent collected here.
+
+## Purpose
+
+The project historically had **no CLA**. This file lists the **external** past
+contributors (everyone except the maintainer, Sai Vignesh Golla / `GodsScion`) whose
+already-merged work we want covered by [`CLA.md`](../../CLA.md). Use the
+[outreach email](outreach-email.md) to contact each person and the
+[retroactive consent form](retroactive-consent.md) to record their agreement.
+
+## How this list was derived (evidence)
+
+This list was built from the repository's own history and in-code attestation
+markers, cross-checked three ways:
+
+1. **`git shortlog -sne`** on `origin/main` — every distinct author name + email and
+   their commit count.
+2. **In-code attestation markers** — `grep -rn "##>" --include="*.py" --include="*.html" .`
+   (the project's `##> ------ Name : github-id OR email - Type ------ ... ##<` format
+   documented in the README).
+3. **Merge-commit PR references** — `git log --merges` — to recover each contributor's
+   **GitHub username** and **PR number** from the merged branch (e.g.
+   `Merge pull request #46 from WINDY-WINDWARD/...`).
+
+The maintainer **Sai Vignesh Golla** (`GodsScion`; emails `saivigneshgolla@outlook.com`
+and `100998531+GodsScion@users.noreply.github.com`) is **excluded** — he is the party
+receiving the grant, not a party to contact.
+
+**Caveats to verify before contacting people:**
+
+- Email addresses come from git commit metadata and may be stale.
+- Where a GitHub username was taken from a `...@users.noreply.github.com` email or a
+  merge-commit branch source, it is reliable; a few real-name authors (Jason Fry, Eric
+  Zhang) map to GitHub handles only via the PR that merged their work — those are noted
+  and marked **(confirm)**.
+- Commit counts include merge commits, so they approximate effort rather than measure it.
+
+## External contributors (excluding the maintainer)
+
+| # | Name | GitHub | Email(s) (from git) | Commits | PR(s) | Attestation in code? | What they contributed |
+|---|------|--------|---------------------|:-------:|-------|:--------------------:|-----------------------|
+| 1 | **Karthik Sarode** | [`WINDY-WINDWARD`](https://github.com/WINDY-WINDWARD) | karthik.sarode23@gmail.com | 7 | #46 | Yes | Flask app + "Applied Jobs history" web UI (`app.py`, `templates/index.html`); fuzzy-logic matching for location-based questions (`runAiBot.py`); related README updates. |
+| 2 | **Dheeraj Deshwal** | [`Dheeraj9811`](https://github.com/Dheeraj9811) | dheeraj20194@iiitd.ac.in; dheerajdeshwal9811@gmail.com | 5 | #40, #41 | Yes | "Answer unknown questions using AI" / user-information feature (`runAiBot.py`, `config/questions.py`, `modules/ai/prompts.py`, `modules/ai/openaiConnections.py`); AI skill-extraction & multi-select double-click bug fix (`modules/clickers_and_finders.py`). |
+| 3 | **Yang Li** | [`MARKYangL`](https://github.com/MARKYangL) | tendernesscurtain@gmail.com | 1 | #50 | Yes | DeepSeek AI integration (`modules/ai/deepseekConnections.py`) plus related feature hooks in `runAiBot.py`, `modules/validator.py`, `modules/ai/prompts.py`, `config/secrets.py`. |
+| 4 | **Tim L** | [`tulXoro`](https://github.com/tulXoro) | tulxoro@hotmail.com | 5 | #63, #65 | Yes | Refactor for multi-LLM compatibility / removing DeepSeek-specific assumptions (`config/secrets.py`, `modules/ai/openaiConnections.py`, `modules/ai/deepseekConnections.py`, `modules/validator.py`). |
+| 5 | **Iliya Brook** | [`IliyaBrook`](https://github.com/IliyaBrook) | iliyabrook1987@gmail.com | 5 | #96 | No | Fallback "Easy Apply" detection via URL pattern (`openSDUIApplyFlow`) in `runAiBot.py`. |
+| 6 | **ArshCypherZ** | [`ArshCypherZ`](https://github.com/ArshCypherZ) | weebarsh@protonmail.com | 3 | #61 | No | Google Gemini support (`modules/ai/geminiConnections.py`, `test_gemini.py`); date-parsing fixes; OpenAI positional-argument fix (`runAiBot.py`, `modules/validator.py`, `config/secrets.py`). |
+| 7 | **Jason Fry** | [`tillydray`](https://github.com/tillydray) **(confirm)** | small.job8148@fastmail.com | 1 | #43 | No | Made the LLM `temperature` parameter optional (`modules/ai/openaiConnections.py`). |
+| 8 | **Eric Zhang** | [`EricZhang2`](https://github.com/EricZhang2) **(confirm)** | yansongzhang@outlook.com | 1 | #39 | No | Fixed a select-then-deselect bug in the LinkedIn job filters (`runAiBot.py`). |
+| 9 | **M4NU5** | [`M4NU5`](https://github.com/M4NU5) | 31220123+M4NU5@users.noreply.github.com | 1 | #35 | No | Pagination fix: match on the button element, not the `li` (`runAiBot.py`). |
+| 10 | **yeswanthmaturi** | [`yeswanthmaturi`](https://github.com/yeswanthmaturi) | 137012121+yeswanthmaturi@users.noreply.github.com | 1 | #71 | No | Raised the CSV field-size limit and added safe truncation for CSV writing (`modules/helpers.py`, `runAiBot.py`). |
+
+**Total: 10 external contributors** (consistent with the expected "~5–11" range).
+
+## Outreach tracking
+
+Fill this in as you contact people. Consent is recorded via
+[`retroactive-consent.md`](retroactive-consent.md).
+
+| # | Name | Contacted (date) | Method | Consent received (date) | Notes |
+|---|------|------------------|--------|-------------------------|-------|
+| 1 | Karthik Sarode |  |  |  |  |
+| 2 | Dheeraj Deshwal |  |  |  |  |
+| 3 | Yang Li |  |  |  |  |
+| 4 | Tim L |  |  |  |  |
+| 5 | Iliya Brook |  |  |  |  |
+| 6 | ArshCypherZ |  |  |  |  |
+| 7 | Jason Fry |  |  |  |  |
+| 8 | Eric Zhang |  |  |  |  |
+| 9 | M4NU5 |  |  |  |  |
+| 10 | yeswanthmaturi |  |  |  |  |
+
+## Open questions for the lawyer
+
+- Is retroactive consent from every past contributor **required** to relicense, or is
+  it a risk-reduction step? What happens for contributors who do not respond?
+- For contributions too small to be independently copyrightable (e.g. a 2-line fix),
+  is consent needed at all?
+- Does the existing in-code **attestation** create any expectation or obligation
+  regarding attribution that survives relicensing?

--- a/docs/contributor-consent/outreach-email.md
+++ b/docs/contributor-consent/outreach-email.md
@@ -1,0 +1,70 @@
+# Outreach email template — past contributors
+
+> **Note:** This is a friendly outreach template, not legal advice. The binding terms
+> live in [`../../CLA.md`](../../CLA.md) and [`retroactive-consent.md`](retroactive-consent.md).
+> Replace `{{NAME}}` and `{{CONTRIBUTION}}` per person (see
+> [`contributors.md`](contributors.md)), and fill the `[link]` placeholders before sending.
+
+---
+
+**Subject:** Quick ask about your contribution to Auto_job_applier_linkedIn 🙏
+
+Hi {{NAME}},
+
+Thank you again for contributing **{{CONTRIBUTION}}** to
+**Auto_job_applier_linkedIn** — it genuinely helped the project and the community. 🙌
+
+As the project matures, I'm formalizing how contributions are licensed by adding a
+**Contributor License Agreement (CLA)** — a normal step for open-source projects as
+they grow. Since you contributed **before** the CLA existed, I'd love your quick
+confirmation that it also covers the work you already merged.
+
+**A few reassurances up front:**
+
+- **The project stays free and open.** It remains available under **AGPL-3.0** — the
+  CLA does not remove or replace the open-source version.
+- **This isn't a new burden.** I'm just asking you to confirm the CLA applies to your
+  already-merged contribution, so the project's licensing is clean and consistent.
+- **You keep the right to use your own work** anywhere else you like.
+- Your contribution and attribution are still yours — you're not being erased.
+
+**In plain English, here's what you'd be agreeing to:**
+
+- You grant me, **Sai Vignesh Golla (as an individual)**, a broad, permanent, worldwide
+  license to your contribution — including the ability to relicense it in the future,
+  potentially under other terms (including commercial/proprietary), **while keeping the
+  free AGPL-3.0 version available**.
+- You confirm the work was yours to give and, as far as you know, doesn't infringe
+  anyone else's rights.
+- You keep a non-exclusive right to use your own contribution elsewhere.
+- (Full details are in the CLA — please do read it.)
+
+**What I'm asking:**
+
+1. Skim the CLA: **[link to CLA.md]**
+2. Confirm it covers your past work using the short consent form: **[link to
+   retroactive-consent.md]**
+   - Easiest option: reply to this email, or comment on **[link to tracking issue/PR]**
+     from your GitHub account, with:
+     > *"I confirm my past contributions to Auto_job_applier_linkedIn are covered by the
+     > project's CLA (CLA.md), and I agree to its terms. — {{NAME}}"*
+
+That's it. If you have any questions or concerns, just reply — I'm happy to talk it
+through, and you're welcome to get your own legal advice before agreeing.
+
+Heads-up in the interest of full transparency: these documents are **templates I'm
+still having reviewed**, so the final wording may be refined — but the intent above
+won't change.
+
+Thanks so much for being part of this. 🚀
+
+Warm regards,
+Sai Vignesh Golla
+GitHub: `GodsScion`
+[your email] · [project link]
+
+---
+
+*Placeholders to fill before sending: `{{NAME}}`, `{{CONTRIBUTION}}`, `[link to CLA.md]`,
+`[link to retroactive-consent.md]`, `[link to tracking issue/PR]`, `[your email]`,
+`[project link]`.*

--- a/docs/contributor-consent/retroactive-consent.md
+++ b/docs/contributor-consent/retroactive-consent.md
@@ -1,0 +1,86 @@
+# Retroactive CLA consent — for already-merged contributions
+
+> ## ⚠️ TEMPLATE — NOT LEGAL ADVICE
+>
+> This is a draft consent form, not legal advice, and it has not been reviewed by a
+> lawyer. Have a qualified lawyer (Indian copyright law and your own jurisdiction)
+> review it before it is used or signed. See the disclaimer in [`../../CLA.md`](../../CLA.md).
+
+## What this is
+
+The **Auto_job_applier_linkedIn** project is adopting a
+[Contributor License Agreement (CLA)](../../CLA.md). Because you contributed to the
+project **before** the CLA existed, we're asking you to confirm — in one short
+statement — that the CLA's terms also cover the contributions you already made and
+that are already merged.
+
+This does **not** ask for anything new beyond the CLA, and it does **not** change the
+fact that the project stays free and open under **AGPL-3.0**.
+
+## Plain-English summary
+
+By signing below, you confirm that:
+
+- Your **already-merged** contributions are covered by [`CLA.md`](../../CLA.md), exactly
+  as if the CLA had been in place when you made them.
+- You grant **Sai Vignesh Golla, an individual** the broad license in the CLA
+  (including the right to relicense, even under proprietary terms), while the AGPL-3.0
+  version remains available.
+- You keep the right to use your own contributions elsewhere (the grant is non-exclusive).
+- The work was yours to give, and to your knowledge it does not infringe anyone else's
+  rights.
+
+If anything here matters to you, please get your own legal advice before signing.
+
+## Consent statement
+
+> I, the person identified below, am a past contributor to the
+> **Auto_job_applier_linkedIn** project (repository:
+> `https://github.com/GodsScion/Auto_job_applier_linkedIn`).
+>
+> I have read the project's Contributor License Agreement ([`CLA.md`](../../CLA.md)),
+> and **I agree that all of my past contributions to the project — including every
+> contribution already merged before the date of this consent — are governed by that
+> CLA**, with the same effect as if I had accepted the CLA at the time I made each
+> contribution.
+>
+> I grant the license (and, to the fullest extent permitted by law, the assignment
+> with license fallback) described in the CLA to **Sai Vignesh Golla, an individual**.
+> I understand the project remains available under AGPL-3.0, and that I retain a
+> non-exclusive right to use my own contributions. I confirm the representations in
+> Section 5 of the CLA are true for my past contributions.
+
+## How to sign (choose one)
+
+**Option A — GitHub (electronic).** Reply to the outreach message, or comment on the
+tracking issue/PR you are pointed to, from your own GitHub account, with exactly:
+
+> *"I confirm my past contributions to Auto_job_applier_linkedIn are covered by the
+> project's CLA (CLA.md), and I agree to its terms. — [your name]"*
+
+**Option B — Signed form (recommended where a copyright assignment is intended to
+take full effect).** Fill in and sign the block below and return it.
+
+> ⚠️ **LAWYER REVIEW.** Under the Indian Copyright Act, an **assignment** likely needs
+> a **signed writing** (§ 19(1)); a GitHub comment may validly grant the **license**
+> (§ 30) but may not perfect the assignment. Confirm which signing method to require,
+> especially for contributors outside India, and whether a qualifying e-signature is
+> acceptable.
+
+### Signature block
+
+- **Full name:** ____________________________________________________
+- **GitHub username:** ______________________________________________
+- **Email used for contributions:** _________________________________
+- **Country of residence:** _________________________________________
+- **Approx. contributions covered (PR #s / description, optional):** _________________
+- **Date (YYYY-MM-DD):** ____________________________________________
+- **Signature:** ____________________________________________________
+
+**Received on behalf of the maintainer:** Sai Vignesh Golla, an individual (GitHub:
+`GodsScion`).
+
+---
+
+*Record each completed consent in
+[`contributors.md`](contributors.md) → "Outreach tracking".*


### PR DESCRIPTION
## Purpose

The project currently has **no CLA**. This PR adds an Individual Contributor License Agreement (CLA) and supporting materials so the maintainer can (a) adopt a CLA for **future** contributions, and (b) ask **past** contributors to confirm the CLA covers their already-merged work — all while the project **remains free and open under AGPL-3.0**.

All rights are granted to **Sai Vignesh Golla, an individual** (GitHub `GodsScion`) — not to any company.

## What's included (all new files)

- **`CLA.md`** — the Individual CLA: plain-English preamble + operative sections (copyright license, assignment with license fallback, patent license, express perpetual/worldwide term, contributor representations, retained contributor rights, moral-rights handling, electronic acceptance, AGPL-3.0-remains clause, India governing law).
- **`CONTRIBUTING.md`** — short guide: links `CLA.md`, states PRs require agreeing to the CLA via the bot, and references (does not duplicate) the existing README code/attestation guidelines.
- **`docs/contributor-consent/contributors.md`** — the list of past external contributors to contact, with derivation notes.
- **`docs/contributor-consent/retroactive-consent.md`** — a short consent form for a past contributor to confirm the CLA covers their already-merged contributions.
- **`docs/contributor-consent/outreach-email.md`** — a friendly outreach email template (`{{NAME}}` / `{{CONTRIBUTION}}` placeholders).
- **`docs/contributor-consent/cla-assistant-setup.md`** — step-by-step to enable the free CLA-assistant for future PRs.

## Rationale for the license-with-assignment-fallback structure

Because the maintainer is in India, the CLA is drafted as **primarily a license plus an assignment with a license fallback**. The Indian Copyright Act requires an **assignment** to be in a signed writing (§ 19(1)), which an electronic click-through likely does not satisfy, whereas a **license** can be granted electronically (§ 30, post-2012). So the CLA leads with a broad, standalone license (perpetual, irrevocable, worldwide, royalty-free, non-exclusive, sublicensable, and expressly permitting **relicensing under any terms including proprietary**), then adds an assignment "to the fullest extent permitted by law" with an express clause that, where the assignment is unenforceable, the license governs. Term and territory are stated **expressly** to avoid the Act's 5-year / India-only defaults (§§ 19(3)/30A).

## ⚠️ TEMPLATE — NOT LEGAL ADVICE — LAWYER REVIEW REQUIRED

**These documents are templates only. They are NOT legal advice and have not been reviewed by a lawyer.** A qualified lawyer (Indian copyright law **and** the jurisdictions of the contributors) must review them before use. Key items flagged inline for review: § 19(1) signed-writing requirement for the assignment; sufficiency of electronic acceptance for the license; moral-rights treatment (§ 57); term/territory defaults; and governing-law enforceability against non-India contributors.

Do not merge until legal review is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)