### PR TITLE
Add local web control panel + one-click launchers (usable without editing code)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ secrets.py
 config/personals.py
 .venv
 apikeys.py
+
+# Local control-panel runtime files — contain your credentials/answers, never commit
+user_config.json
+.bot_run.log
+.bot_run.pid

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # LinkedIn AI Auto Job Applier 🤖
-This is an web scraping bot that automates the process of job applications on LinkedIn. It searches for jobs relevant to you, answers all questions in application form, customizes your resume based on the collected job information, such as skills required, description, about company, etc. and applies to the job. Can apply 100+ jobs in less than 1 hour. 
+This is a free, open-source tool that automates job applications on LinkedIn. It runs entirely on your own computer, using your own LinkedIn account. It finds jobs relevant to you, fills in the application questions, tailors your resume to each job's details (required skills, description, about the company, etc.), and applies. Can apply to 100+ jobs in under an hour. 
 
 
 ## 📽️ See it in Action
@@ -29,13 +29,13 @@ Click on above image to watch the demo or use this link https://youtu.be/gMbB1fW
 Click on above image to watch the tutorial for installation and configuration or use this link https://youtu.be/f9rdz74e1lM (Recommended to watch it in 2x speed)
 
 1. [Python 3.10](https://www.python.org/) or above. Visit https://www.python.org/downloads/ to download and install Python, or for windows you could visit Microsoft Store and search for "Python". **Please make sure Python is added to Path in System Environment Variables**.
-2. Install necessary [Undetected Chromedriver](https://pypi.org/project/undetected-chromedriver/), [PyAutoGUI](https://pypi.org/project/PyAutoGUI/) and [Setuptools](https://pypi.org/project/setuptools/) packages. After Python is installed, OPEN a console/terminal or shell, Use below command that uses the [pip](https://pip.pypa.io/en/stable) command-line tool to install these 3 package.
+2. Install the required Python packages. After Python is installed, open a console/terminal in the project folder and run the command below (it uses [pip](https://pip.pypa.io/en/stable) to install everything listed in `requirements.txt`).
   ```
-  pip install undetected-chromedriver pyautogui setuptools openai flask-cors flask
+  pip install -r requirements.txt
   ```
 3. Download and install latest version of [Google Chrome](https://www.google.com/chrome) in it's default location, visit https://www.google.com/chrome to download it's installer.
 4. Clone the current git repo or download it as a zip file, url to the latest update https://github.com/GodsScion/Auto_job_applier_linkedIn.
-5. (Not needed if you set `stealth_mode = True` in `config/settings.py` ) Download and install the appropriate [Chrome Driver](https://googlechromelabs.github.io/chrome-for-testing/) for Google Chrome and paste it in the location Chrome was installed, visit https://googlechromelabs.github.io/chrome-for-testing/ to download.
+5. (Not needed if you set `auto_manage_driver = True` in `config/settings.py`, which downloads the matching driver for you automatically.) Otherwise, download the [Chrome Driver](https://googlechromelabs.github.io/chrome-for-testing/) that matches your Google Chrome version and place it where Chrome is installed. Visit https://googlechromelabs.github.io/chrome-for-testing/ to download.
   <br> <br>
   ***OR*** 
   <br> <br>
@@ -51,7 +51,7 @@ Click on above image to watch the tutorial for installation and configuration or
 2. Open `questions.py` file in `/config` folder and enter your answers for application questions, configure wether you want the bot to pause before submission or pause if it can't answer unknown questions.
 3. Open `search.py` file in `/config` folder and enter your search preferences, job filters, configure the bot as per your needs (these settings decide which jobs to apply for or skip).
 4. Open `secrets.py` file in `/config` folder and enter your LinkedIn username, password to login and OpenAI API Key for generation of job tailored resumes and cover letters (This entire step is optional). If you do not provide username or password or leave them as default, it will login with saved profile in browser, if failed will ask you to login manually.
-5. Open `settings.py` file in `/config` folder to configure the bot settings like, keep screen awake, click intervals (click intervals are randomized to seem like human behavior), run in background, stealth mode (to avoid bot detection), etc. as per your needs.
+5. Open `settings.py` file in `/config` folder to configure settings like keep screen awake, click interval (time to wait between actions), run in background, automatic Chrome-driver management, etc. as per your needs.
 6. (Optional) Don't forget to add you default resume in the location you mentioned in `default_resume_path = "all resumes/default/resume.pdf"` given in `/config/questions.py`. If one is not provided, it will use your previous resume submitted in LinkedIn or (In Development) generate custom resume if OpenAI APT key is provided!
 7. Run `runAiBot.py` and see the magic happen.
 8. To run the Applied Jobs history UI, run `app.py` and open web browser on `http://localhost:5000`.
@@ -263,22 +263,22 @@ Once your code is tested, your changes will be merged to the `main` branch in ne
 
 ## 📜 Disclaimer
 
-**This program is for educational purposes only. By downloading, using, copying, replicating, or interacting with this program or its code, you acknowledge and agree to abide by all the Terms, Conditions, Policies, and Licenses mentioned, which are subject to modification without prior notice. The responsibility of staying informed of any changes or updates bears upon yourself. For the latest Terms & Conditions, Licenses, or Policies, please refer to [Auto Job Applier](https://github.com/GodsScion/Auto_job_applier_linkedIn). Additionally, kindly adhere to and comply with LinkedIn's terms of service and policies pertaining to web scraping. Usage is at your own risk. The creators and contributors of this program emphasize that they bear no responsibility or liability for any misuse, damages, or legal consequences resulting from its usage.**
+**This tool runs on your own computer and acts through your own accounts. It is provided free and open source, with no warranty of any kind. You are responsible for how you use it, including making sure your use complies with the terms of any website or service you use it with. The authors and contributors accept no liability for how it is used.**
 
 
 ## 🏛️ Terms and Conditions
 
 Please consider the following:
 
-- **LinkedIn Policies**: LinkedIn has specific policies regarding web scraping and data collection. The responsibility to review and comply with these policies before engaging, interacting, or undertaking any actions with this program bears upon yourself. Be aware of the limitations and restrictions imposed by LinkedIn to avoid any potential violation(s).
+- **LinkedIn Policies**: LinkedIn has policies regarding automated activity on its platform. It is your responsibility to review and comply with them before using this tool with your account.
 
 - **No Warranties or Guarantees**: This program is provided as-is, without any warranties or guarantees of any kind. The accuracy, reliability, and effectiveness of the program cannot be guaranteed. Use it at your own risk.
 
 - **Disclaimer of Liability**: The creators and contributors of this program shall not be held responsible or liable for any damages or consequences arising from the direct or indirect use, interaction, or actions performed with this program. This includes but is not limited to any legal issues, loss of data, or other damages incurred.
 
-- **Use at Your Own Risk**: It is important to exercise caution and ensure that your usage, interactions, and actions with this program comply with the applicable laws and regulations. Understand the potential risks and consequences associated with web scraping and data collection activities.
+- **Use at Your Own Risk**: It is important to exercise caution and ensure that your usage, interactions, and actions with this program comply with applicable laws, regulations, and the terms of the services you use it with.
 
-- **Chrome Driver**: This program utilizes the Chrome Driver for web scraping. Please review and comply with the terms and conditions specified for [Chrome Driver](https://chromedriver.chromium.org/home).
+- **Chrome Driver**: This program uses the Chrome Driver to control your browser. Please review and comply with the terms and conditions specified for [Chrome Driver](https://chromedriver.chromium.org/home).
 
 
 ## ⚖️ License

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Click on above image to watch the demo or use this link https://youtu.be/gMbB1fW
 - [Introduction](#linkedin-ai-auto-job-applier-)
 - [Demo Video](#%EF%B8%8F-see-it-in-action)
 - [Index](#-content)
+- [Easy start (recommended)](#-easy-start-recommended)
 - [Install](#%EF%B8%8F-how-to-install)
 - [Configure](#-how-to-configure)
 - [Contributor Guidelines](#‍-contributor-guidelines)
@@ -20,6 +21,27 @@ Click on above image to watch the demo or use this link https://youtu.be/gMbB1fW
 - [License](#%EF%B8%8F-license)
 - [Socials](#-socials)
 - [Support and Discussions](#-community-support-and-discussions)
+
+<br>
+
+## 🚀 Easy start (recommended)
+
+New here, or not comfortable editing code? Use the built-in control panel. You set everything up in your web browser and run the tool with a button - no editing Python files, no terminal commands.
+
+1. **Install Python once.** Get it from https://www.python.org/downloads/ (on Windows, tick **"Add Python to PATH"** during install). You also need [Google Chrome](https://www.google.com/chrome).
+2. **Download this project** (green "Code" button → "Download ZIP", then unzip; or clone it).
+3. **Double-click the launcher for your system:**
+    - **macOS:** `start.command`
+    - **Windows:** `start.bat`
+    - **Linux:** `start.sh` (run `./start.sh` in a terminal)
+
+    The first run sets things up automatically (it may take a minute). After that it's quick.
+4. Your browser opens the **control panel** at `http://127.0.0.1:5000`. Fill in the tabs - **Account, Profile, Search, Filters, Run settings** - and click **Save**.
+5. Go to the **Run** tab and click **Start**. A Chrome window opens and begins applying - keep it in the foreground. You can watch progress in the log and click **Stop** any time.
+
+Everything stays on your own computer: your details are saved locally in `user_config.json` (never uploaded), and the control panel is reachable only from this machine. If you prefer the classic setup, the manual steps below still work exactly as before.
+
+[back to index](#-content)
 
 <br>
 

--- a/app.py
+++ b/app.py
@@ -1,27 +1,244 @@
+'''
+Author:     Sai Vignesh Golla
+License:    GNU Affero General Public License
+            https://www.gnu.org/licenses/agpl-3.0.en.html
+GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
+
+Local "control panel" web app. It lets a non-technical person configure and run
+the tool from a browser instead of editing Python files and using a terminal.
+
+IMPORTANT - how configuration works:
+  * This app reads/writes ONLY `user_config.json` at the project root.
+  * It NEVER edits the config/*.py files.
+  * The config/*.py modules load user_config.json over their built-in defaults
+    (see config/_overrides.py), so saving here changes the tool's behaviour
+    while leaving the classic "edit the .py files" workflow intact. With no
+    user_config.json present the tool behaves exactly as it always has.
+
+SECURITY: this app handles LinkedIn credentials, so it binds to 127.0.0.1 only
+(never 0.0.0.0) and runs with debug OFF. Do not change these.
+'''
+
 from flask import Flask, request, jsonify, render_template
 from flask_cors import CORS
 import csv
 from datetime import datetime
 import os
+import sys
+import json
+import copy
+import signal
+import subprocess
+import threading
+import importlib
+
+import config_schema
+from config import _overrides
 
 app = Flask(__name__)
 CORS(app)
 
+# Project root is the folder this file lives in.
+ROOT = os.path.dirname(os.path.abspath(__file__))
+USER_CONFIG_PATH = _overrides.USER_CONFIG_PATH
+LOG_PATH = os.path.join(ROOT, ".bot_run.log")
+PID_PATH = os.path.join(ROOT, ".bot_run.pid")
+
 PATH = 'all excels/'
+
+
+# ===========================================================================
+# Default config values (the pristine config/*.py defaults, ignoring any
+# user_config.json). Captured once at startup so /api/config can always show
+# "default overlaid with the user's current saved values".
+# ===========================================================================
+def _load_defaults() -> dict:
+    '''
+    Import each config module with overrides temporarily disabled, so we read
+    the untouched Python defaults regardless of whether user_config.json exists
+    right now. Returns {config_module: {key: default_value}}.
+    '''
+    original_loader = _overrides.load_user_config
+    _overrides.load_user_config = lambda: {}
+    try:
+        import config.secrets as _secrets
+        import config.personals as _personals
+        import config.questions as _questions
+        import config.search as _search
+        import config.settings as _settings
+        modules = {
+            "secrets": _secrets,
+            "personals": _personals,
+            "questions": _questions,
+            "search": _search,
+            "settings": _settings,
+        }
+        # Reload in case they were already imported (with real overrides) earlier.
+        for module in modules.values():
+            importlib.reload(module)
+        defaults = {}
+        for field in config_schema.iter_fields():
+            module_name = field["config_module"]
+            key = field["key"]
+            module = modules.get(module_name)
+            defaults.setdefault(module_name, {})[key] = getattr(module, key, None)
+        return defaults
+    finally:
+        _overrides.load_user_config = original_loader
+
+
+DEFAULTS = _load_defaults()
+
+
+# ===========================================================================
+# Config API helpers
+# ===========================================================================
+def _effective_config() -> dict:
+    '''
+    Return {config_module: {key: value}} of the pristine defaults overlaid with
+    the CURRENT contents of user_config.json (re-read from disk on every call).
+    Only keys defined in config_schema are included.
+    '''
+    effective = copy.deepcopy(DEFAULTS)
+    user = _overrides.load_user_config()
+    for field in config_schema.iter_fields():
+        module_name = field["config_module"]
+        key = field["key"]
+        section = user.get(module_name)
+        if isinstance(section, dict) and key in section:
+            effective[module_name][key] = section[key]
+    return effective
+
+
+def _coerce(field_type: str, value):
+    '''
+    Coerce an incoming JSON value into the type declared for the field in the
+    schema. Raises ValueError on invalid numbers so the caller can reject them.
+    '''
+    if field_type in ("text", "password", "textarea", "select"):
+        return "" if value is None else str(value)
+
+    if field_type == "number":
+        if isinstance(value, bool):
+            raise ValueError("expected a number, got a boolean")
+        if isinstance(value, (int, float)):
+            number = value
+        else:
+            text = str(value).strip()
+            if text == "":
+                raise ValueError("expected a number, got an empty value")
+            number = float(text)
+        # Keep whole numbers as ints (the config defaults are ints).
+        if isinstance(number, float) and number.is_integer():
+            return int(number)
+        return number
+
+    if field_type == "bool":
+        if isinstance(value, bool):
+            return value
+        return str(value).strip().lower() in ("true", "1", "yes", "on")
+
+    if field_type == "list":
+        if isinstance(value, list):
+            return [str(item).strip() for item in value if str(item).strip() != ""]
+        text = str(value).strip()
+        if text == "":
+            return []
+        return [item.strip() for item in text.split(",") if item.strip() != ""]
+
+    # Unknown type: pass through untouched.
+    return value
+
+
+# ===========================================================================
+# Bot subprocess management (run / stop / status / logs)
+# ===========================================================================
+_bot_proc = None
+_bot_lock = threading.Lock()
+
+
+def _bot_command():
+    '''The command used to launch the bot. Isolated so tests can monkeypatch it.'''
+    return [sys.executable, os.path.join(ROOT, "runAiBot.py")]
+
+
+def _is_running() -> bool:
+    '''True if the tracked bot subprocess exists and has not exited.'''
+    global _bot_proc
+    if _bot_proc is None:
+        return False
+    if _bot_proc.poll() is None:
+        return True
+    # Process has exited; clean up tracking + PID file.
+    _bot_proc = None
+    _remove_pid_file()
+    return False
+
+
+def _remove_pid_file():
+    try:
+        os.remove(PID_PATH)
+    except OSError:
+        pass
+
+
+def _terminate(proc) -> None:
+    '''Terminate the subprocess and, where feasible, its child processes.'''
+    if proc is None or proc.poll() is not None:
+        return
+    try:
+        if os.name == "nt":
+            # Kill the whole process tree on Windows.
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+        else:
+            # We launched with start_new_session=True, so the child is its own
+            # process-group leader; signal the whole group.
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            except (ProcessLookupError, PermissionError):
+                proc.terminate()
+    except Exception:
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+    # Give it a moment, then force-kill if still alive.
+    try:
+        proc.wait(timeout=5)
+    except Exception:
+        try:
+            if os.name != "nt":
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            else:
+                proc.kill()
+        except Exception:
+            pass
+
+
 ##> ------ Karthik Sarode : karthik.sarode23@gmail.com - UI for excel files ------
 @app.route('/')
 def home():
-    """Displays the home page of the application."""
+    """Renders the control panel single-page app."""
+    return render_template('control_panel.html')
+
+
+@app.route('/history')
+def history():
+    """Renders the original standalone applied-jobs history page (kept reachable)."""
     return render_template('index.html')
+
 
 @app.route('/applied-jobs', methods=['GET'])
 def get_applied_jobs():
     '''
     Retrieves a list of applied jobs from the applications history CSV file.
-    
-    Returns a JSON response containing a list of jobs, each with details such as 
+
+    Returns a JSON response containing a list of jobs, each with details such as
     Job ID, Title, Company, HR Name, HR Link, Job Link, External Job link, and Date Applied.
-    
+
     If the CSV file is not found, returns a 404 error with a relevant message.
     If any other exception occurs, returns a 500 error with the exception message.
     '''
@@ -64,10 +281,10 @@ def update_applied_date(job_id):
     try:
         data = []
         csvPath = PATH + 'all_applied_applications_history.csv'
-        
+
         if not os.path.exists(csvPath):
             return jsonify({"error": f"CSV file not found at {csvPath}"}), 404
-            
+
         # Read current CSV content
         with open(csvPath, 'r', encoding='utf-8') as file:
             reader = csv.DictReader(file)
@@ -78,7 +295,7 @@ def update_applied_date(job_id):
                     row['Date Applied'] = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
                     found = True
                 data.append(row)
-        
+
         if not found:
             return jsonify({"error": f"Job ID {job_id} not found"}), 404
 
@@ -86,13 +303,167 @@ def update_applied_date(job_id):
             writer = csv.DictWriter(file, fieldnames=fieldNames)
             writer.writeheader()
             writer.writerows(data)
-        
+
         return jsonify({"message": "Date Applied updated successfully"}), 200
     except Exception as e:
         print(f"Error updating applied date: {str(e)}")  # Debug log
         return jsonify({"error": str(e)}), 500
 
-if __name__ == '__main__':
-    app.run(debug=True)
-
 ##<
+
+
+# ===========================================================================
+# Control-panel API
+# ===========================================================================
+@app.route('/api/schema', methods=['GET'])
+def api_schema():
+    '''Returns the field schema the UI renders its forms from.'''
+    return jsonify(config_schema.SCHEMA)
+
+
+@app.route('/api/config', methods=['GET'])
+def api_get_config():
+    '''
+    Returns the effective config: pristine defaults overlaid with the current
+    user_config.json, grouped by config module (secrets, personals, questions,
+    search, settings).
+    '''
+    return jsonify(_effective_config())
+
+
+@app.route('/api/config', methods=['POST'])
+def api_save_config():
+    '''
+    Accepts {config_module: {key: value}}, validates against the schema, coerces
+    each value to its declared type, rejects unknown modules/keys, merges into
+    user_config.json (read-modify-write) and returns the full saved config.
+    '''
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        return jsonify({"error": "Expected a JSON object of {section: {key: value}}"}), 400
+
+    valid = config_schema.valid_keys()
+    unknown = []
+    coerced = {}
+
+    for section, values in payload.items():
+        if not isinstance(values, dict):
+            return jsonify({"error": f"Section '{section}' must be an object"}), 400
+        if section not in valid:
+            unknown.append(section)
+            continue
+        for key, value in values.items():
+            field = valid[section].get(key)
+            if field is None:
+                unknown.append(f"{section}.{key}")
+                continue
+            try:
+                coerced.setdefault(section, {})[key] = _coerce(field["type"], value)
+            except ValueError as err:
+                return jsonify({"error": f"Invalid value for '{section}.{key}': {err}"}), 400
+
+    if unknown:
+        return jsonify({"error": "Unknown settings rejected", "unknown": unknown}), 400
+
+    # Read-modify-write user_config.json.
+    current = _overrides.load_user_config()
+    for section, values in coerced.items():
+        target = current.get(section)
+        if not isinstance(target, dict):
+            target = {}
+        target.update(values)
+        current[section] = target
+
+    try:
+        with open(USER_CONFIG_PATH, "w", encoding="utf-8") as file:
+            json.dump(current, file, indent=2, ensure_ascii=False)
+    except OSError as err:
+        return jsonify({"error": f"Could not save settings: {err}"}), 500
+
+    return jsonify(current)
+
+
+@app.route('/api/run', methods=['POST'])
+def api_run():
+    '''Starts the bot as a subprocess if it isn't already running.'''
+    global _bot_proc
+    with _bot_lock:
+        if _is_running():
+            return jsonify({"running": True, "pid": _bot_proc.pid,
+                            "message": "The tool is already running."})
+        try:
+            # Truncate the log at the start of each run.
+            log_file = open(LOG_PATH, "w", encoding="utf-8")
+            popen_kwargs = {
+                "cwd": ROOT,
+                "stdout": log_file,
+                "stderr": subprocess.STDOUT,
+            }
+            if os.name == "nt":
+                popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+            else:
+                popen_kwargs["start_new_session"] = True
+            _bot_proc = subprocess.Popen(_bot_command(), **popen_kwargs)
+        except Exception as err:
+            return jsonify({"running": False, "error": str(err)}), 500
+        try:
+            with open(PID_PATH, "w", encoding="utf-8") as pid_file:
+                pid_file.write(str(_bot_proc.pid))
+        except OSError:
+            pass
+        return jsonify({"running": True, "pid": _bot_proc.pid})
+
+
+@app.route('/api/stop', methods=['POST'])
+def api_stop():
+    '''Stops the running bot subprocess (and its children where possible).'''
+    global _bot_proc
+    with _bot_lock:
+        if _bot_proc is not None:
+            _terminate(_bot_proc)
+            _bot_proc = None
+        _remove_pid_file()
+        return jsonify({"running": False})
+
+
+@app.route('/api/status', methods=['GET'])
+def api_status():
+    '''Reports whether the bot subprocess is currently running.'''
+    with _bot_lock:
+        running = _is_running()
+        pid = _bot_proc.pid if (running and _bot_proc is not None) else None
+        return jsonify({"running": running, "pid": pid})
+
+
+@app.route('/api/logs', methods=['GET'])
+def api_logs():
+    '''
+    Returns the run log starting from byte offset ?offset=N, plus the byte
+    offset to read from next time. The UI polls this while the bot runs.
+    '''
+    try:
+        offset = int(request.args.get("offset", 0))
+    except (TypeError, ValueError):
+        offset = 0
+    if offset < 0:
+        offset = 0
+    if not os.path.exists(LOG_PATH):
+        return jsonify({"content": "", "next_offset": 0})
+    try:
+        with open(LOG_PATH, "rb") as log_file:
+            log_file.seek(0, os.SEEK_END)
+            size = log_file.tell()
+            if offset > size:
+                # Log was truncated (a new run started); start over.
+                offset = 0
+            log_file.seek(offset)
+            data = log_file.read()
+        content = data.decode("utf-8", errors="replace")
+        return jsonify({"content": content, "next_offset": offset + len(data)})
+    except OSError as err:
+        return jsonify({"content": "", "next_offset": offset, "error": str(err)})
+
+
+if __name__ == '__main__':
+    # SECURITY: localhost only, debug OFF. This app handles credentials.
+    app.run(host="127.0.0.1", port=5000, debug=False)

--- a/config/_overrides.py
+++ b/config/_overrides.py
@@ -1,0 +1,55 @@
+'''
+Author:     Sai Vignesh Golla
+License:    GNU Affero General Public License
+            https://www.gnu.org/licenses/agpl-3.0.en.html
+GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
+
+Loads user settings saved by the local control panel (see app.py) from
+`user_config.json` at the project root, and applies them over the Python
+defaults defined in the config/*.py files.
+
+If `user_config.json` does not exist, everything here is a no-op and the tool
+behaves exactly as it always has: configuration comes entirely from the
+config/*.py defaults. This keeps the classic "edit the .py files" workflow
+fully working for existing users.
+'''
+
+import os
+import json
+
+# This file lives in <project_root>/config/, so the project root is one level up.
+_CONFIG_DIR = os.path.dirname(os.path.abspath(__file__))
+_ROOT_DIR = os.path.dirname(_CONFIG_DIR)
+USER_CONFIG_PATH = os.path.join(_ROOT_DIR, "user_config.json")
+
+
+def load_user_config() -> dict:
+    '''
+    Returns the full override dictionary from `user_config.json`, or an empty
+    dict if the file is missing, unreadable, or not valid JSON. Never raises.
+    '''
+    try:
+        with open(USER_CONFIG_PATH, "r", encoding="utf-8") as file:
+            data = json.load(file)
+            return data if isinstance(data, dict) else {}
+    except (FileNotFoundError, json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def apply(module_name: str, module_globals: dict) -> None:
+    '''
+    Overrides a config module's existing globals with values from the matching
+    section of `user_config.json`.
+
+    - `module_name` is the module's `__name__` (e.g. "config.settings"); the last
+      dotted part is the section name looked up in the JSON ("settings").
+    - Only keys that ALREADY exist as globals in the module are applied, so the
+      JSON can never introduce new names into the config namespace.
+    '''
+    section_name = module_name.split(".")[-1]
+    section = load_user_config().get(section_name, {})
+    if not isinstance(section, dict):
+        return
+    for key, value in section.items():
+        if key in module_globals:
+            module_globals[key] = value

--- a/config/personals.py
+++ b/config/personals.py
@@ -83,4 +83,9 @@ Your support, whether through donations big or small or simply spreading the wor
 Gratefully yours 🙏🏻,
 Sai Vignesh Golla
 '''
+
+# --- Load user settings saved by the local control panel (user_config.json).
+# --- No-op if that file is absent: values fall back to the defaults above.
+from config import _overrides as _o
+_o.apply(__name__, globals())
 ############################################################################################################

--- a/config/questions.py
+++ b/config/questions.py
@@ -162,4 +162,9 @@ Your support, whether through donations big or small or simply spreading the wor
 Gratefully yours 🙏🏻,
 Sai Vignesh Golla
 '''
+
+# --- Load user settings saved by the local control panel (user_config.json).
+# --- No-op if that file is absent: values fall back to the defaults above.
+from config import _overrides as _o
+_o.apply(__name__, globals())
 ############################################################################################################

--- a/config/search.py
+++ b/config/search.py
@@ -123,4 +123,9 @@ Your support, whether through donations big or small or simply spreading the wor
 Gratefully yours 🙏🏻,
 Sai Vignesh Golla
 '''
+
+# --- Load user settings saved by the local control panel (user_config.json).
+# --- No-op if that file is absent: values fall back to the defaults above.
+from config import _overrides as _o
+_o.apply(__name__, globals())
 ############################################################################################################

--- a/config/secrets.py
+++ b/config/secrets.py
@@ -101,4 +101,9 @@ Your support, whether through donations big or small or simply spreading the wor
 Gratefully yours 🙏🏻,
 Sai Vignesh Golla
 '''
+
+# --- Load user settings saved by the local control panel (user_config.json).
+# --- No-op if that file is absent: values fall back to the defaults above.
+from config import _overrides as _o
+_o.apply(__name__, globals())
 ############################################################################################################

--- a/config/settings.py
+++ b/config/settings.py
@@ -82,14 +82,14 @@ smooth_scroll = False               # True or False, Note: True or False are cas
 # If enabled (True), the program would keep your screen active and prevent PC from sleeping. Instead you could disable this feature (set it to false) and adjust your PC sleep settings to Never Sleep or a preferred time. 
 keep_screen_awake = True            # True or False, Note: True or False are case-sensitive (Note: Will temporarily deactivate when any application dialog boxes are present (Eg: Pause before submit, Help needed for a question..))
 
-# Run in undetected mode to bypass anti-bot protections (Preview Feature, UNSTABLE. Recommended to leave it as False)
-stealth_mode = True                # True or False, Note: True or False are case-sensitive
+# Automatically download and manage the matching Chrome driver, so you don't have to install ChromeDriver yourself. If False, you must install a matching ChromeDriver manually (see setup step 5).
+auto_manage_driver = True          # True or False, Note: True or False are case-sensitive
 
 # Do you want to get alerts on errors related to AI API connection?
 showAiErrorAlerts = False            # True or False, Note: True or False are case-sensitive
 
 # Use ChatGPT for resume building (Experimental Feature can break the application. Recommended to leave it as False) 
-# use_resume_generator = False       # True or False, Note: True or False are case-sensitive ,   This feature may only work with 'stealth_mode = True'. As ChatGPT website is hosted by CloudFlare which is protected by Anti-bot protections!
+# use_resume_generator = False       # True or False, Note: True or False are case-sensitive ,   This experimental feature may only work with 'auto_manage_driver = True'.
 
 
 
@@ -116,4 +116,9 @@ Your support, whether through donations big or small or simply spreading the wor
 Gratefully yours 🙏🏻,
 Sai Vignesh Golla
 '''
+
+# --- Load user settings saved by the local control panel (user_config.json).
+# --- No-op if that file is absent: values fall back to the defaults above.
+from config import _overrides as _o
+_o.apply(__name__, globals())
 ############################################################################################################

--- a/config_schema.py
+++ b/config_schema.py
@@ -1,0 +1,252 @@
+'''
+Author:     Sai Vignesh Golla
+License:    GNU Affero General Public License
+            https://www.gnu.org/licenses/agpl-3.0.en.html
+GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
+
+Describes every user-editable setting that the local control panel (app.py +
+templates/control_panel.html) exposes in the browser.
+
+The panel NEVER edits the config/*.py files. It reads and writes only
+`user_config.json` at the project root, which the config/*.py modules load and
+apply over their built-in defaults (see config/_overrides.py). This schema is
+the single source of truth the web UI renders forms from.
+
+Each field is a dict:
+    {
+      "section":       tab it appears under in the UI (Account, Profile, ...),
+      "config_module": the config/*.py module the setting lives in. This is ALSO
+                       the key used for it inside user_config.json, so it must
+                       match the module name exactly (secrets, personals,
+                       questions, search, settings),
+      "key":           the variable name in that module,
+      "label":         short human label,
+      "type":          one of text, password, textarea, number, bool, select, list,
+      "help":          plain-language explanation (from the config comments),
+      "options":       list of allowed values (select fields only),
+    }
+
+Field types:
+    text      - single line of text
+    password  - single line, masked in the browser
+    textarea  - multi-line text
+    number    - stored as a number (int/float), not quoted
+    bool      - True / False checkbox
+    select    - pick one from "options"
+    list      - comma-separated text in the UI, stored as a JSON list
+'''
+
+
+def _f(section, config_module, key, label, ftype, help, options=None):
+    field = {
+        "section": section,
+        "config_module": config_module,
+        "key": key,
+        "label": label,
+        "type": ftype,
+        "help": help,
+    }
+    if options is not None:
+        field["options"] = options
+    return field
+
+
+# ---------------------------------------------------------------------------
+# The schema, grouped into tabs. Each tab is {"section", "fields": [...]}.
+# ---------------------------------------------------------------------------
+SCHEMA = [
+    {
+        "section": "Account",
+        "fields": [
+            _f("Account", "secrets", "username", "LinkedIn email", "text",
+               "The email address you sign in to LinkedIn with. Optional - if left blank the tool tries the browser's saved login, and asks you to log in by hand if that fails."),
+            _f("Account", "secrets", "password", "LinkedIn password", "password",
+               "Your LinkedIn password. Stored only on this computer in user_config.json (never uploaded anywhere). Optional - leave blank to log in manually."),
+            _f("Account", "secrets", "use_AI", "Use AI", "bool",
+               "Turn on AI help for tailoring answers, resumes and cover letters. Only turn this on if you have a local AI model running or a paid API key (see the fields below). Off by default."),
+            _f("Account", "secrets", "ai_provider", "AI provider", "select",
+               "Which AI service to use. Pick 'openai' for OpenAI or any OpenAI-compatible service (like Ollama or LM Studio), 'deepseek' for DeepSeek, or 'gemini' for Google Gemini.",
+               options=["openai", "deepseek", "gemini"]),
+            _f("Account", "secrets", "llm_api_url", "AI API URL", "text",
+               "The address of your AI service. Examples: https://api.openai.com/v1/ , http://localhost:1234/v1/ , https://api.deepseek.com . Keep the trailing slash. You may not need this for Gemini."),
+            _f("Account", "secrets", "llm_api_key", "AI API key", "password",
+               "Your AI service API key. Use 'not-needed' for local models like Ollama. Leaving it wrong will cause errors when AI is on."),
+            _f("Account", "secrets", "llm_model", "AI model name", "text",
+               "The model to use. Examples: gpt-4o, gpt-5-mini, llama-3.2-3b-instruct, gemini-2.5-flash, deepseek-llm:latest."),
+            _f("Account", "secrets", "llm_spec", "AI API type", "text",
+               "How the tool should talk to the model. Most services work with 'openai'. Options include openai, openai-like, deepseek, gemini."),
+            _f("Account", "secrets", "stream_output", "Stream AI output", "bool",
+               "Show the AI's answer as it is being written. Off is a little faster; on feels more responsive."),
+        ],
+    },
+    {
+        "section": "Profile",
+        "fields": [
+            # --- personals.py ---
+            _f("Profile", "personals", "first_name", "First name", "text",
+               "Your legal first name."),
+            _f("Profile", "personals", "middle_name", "Middle name", "text",
+               "Your middle name. Leave blank if you don't have one."),
+            _f("Profile", "personals", "last_name", "Last name", "text",
+               "Your legal last name."),
+            _f("Profile", "personals", "phone_number", "Phone number", "text",
+               "A valid phone number. Applications often require this."),
+            _f("Profile", "personals", "current_city", "Current city", "text",
+               "The city you live in. If left blank, the tool fills in the job's location instead."),
+            _f("Profile", "personals", "street", "Street address", "text",
+               "Your street address. Some applications require it."),
+            _f("Profile", "personals", "state", "State / region", "text",
+               "Your state or region."),
+            _f("Profile", "personals", "zipcode", "ZIP / postal code", "text",
+               "Your ZIP or postal code."),
+            _f("Profile", "personals", "country", "Country", "text",
+               "The country you live in."),
+            _f("Profile", "personals", "ethnicity", "Ethnicity / race", "select",
+               "Used for optional US equal-opportunity questions. Choose 'Decline' to prefer not to answer. A blank leaves the question unanswered, but some companies make it required.",
+               options=["", "Decline", "Hispanic/Latino", "American Indian or Alaska Native", "Asian", "Black or African American", "Native Hawaiian or Other Pacific Islander", "White", "Other"]),
+            _f("Profile", "personals", "gender", "Gender", "select",
+               "Used for optional equal-opportunity questions. Choose 'Decline' to prefer not to answer, or leave blank to skip (some companies require it).",
+               options=["", "Male", "Female", "Other", "Decline"]),
+            _f("Profile", "personals", "disability_status", "Disability status", "select",
+               "Do you have, or have a record of, a disability? Choose 'Decline' to prefer not to answer.",
+               options=["Yes", "No", "Decline"]),
+            _f("Profile", "personals", "veteran_status", "Veteran status", "select",
+               "Your veteran status. Choose 'Decline' to prefer not to answer.",
+               options=["Yes", "No", "Decline"]),
+            # --- questions.py ---
+            _f("Profile", "questions", "years_of_experience", "Years of experience", "text",
+               "What to answer for 'how many years of experience do you have' questions. A number in text, e.g. 0, 1, 3, 5."),
+            _f("Profile", "questions", "require_visa", "Need visa sponsorship?", "select",
+               "Do you need visa sponsorship now or in the future?",
+               options=["Yes", "No"]),
+            _f("Profile", "questions", "website", "Portfolio website", "text",
+               "Link to your portfolio or personal website. Leave blank to skip this question."),
+            _f("Profile", "questions", "linkedIn", "LinkedIn profile URL", "text",
+               "The link to your LinkedIn profile, e.g. https://www.linkedin.com/in/yourname ."),
+            _f("Profile", "questions", "us_citizenship", "Citizenship status", "select",
+               "Your work-authorization / citizenship status for US applications.",
+               options=["U.S. Citizen/Permanent Resident", "Non-citizen allowed to work for any employer", "Non-citizen allowed to work for current employer", "Non-citizen seeking work authorization", "Canadian Citizen/Permanent Resident", "Other"]),
+            _f("Profile", "questions", "desired_salary", "Desired salary", "number",
+               "Your expected salary or CTC as a plain number (no currency symbols or commas), e.g. 100000. Some forms only accept numbers."),
+            _f("Profile", "questions", "current_ctc", "Current salary", "number",
+               "Your current salary or CTC as a plain number, e.g. 80000."),
+            _f("Profile", "questions", "notice_period", "Notice period (days)", "number",
+               "Your notice period in days, e.g. 0, 15, 30. The tool converts to weeks or months if a form asks that way."),
+            _f("Profile", "questions", "linkedin_headline", "LinkedIn headline", "text",
+               "A short professional headline, e.g. 'Full Stack Developer, MSc Computer Science, 4+ years experience'. Leave blank to skip."),
+            _f("Profile", "questions", "linkedin_summary", "LinkedIn summary", "textarea",
+               "A few sentences about your background and skills. Used to answer 'tell us about yourself' style questions. Leave blank to skip."),
+            _f("Profile", "questions", "cover_letter", "Cover letter", "textarea",
+               "A default cover letter to submit when one is requested. Leave blank to skip."),
+            _f("Profile", "questions", "recent_employer", "Most recent employer", "text",
+               "The name of your most recent employer."),
+            _f("Profile", "questions", "confidence_level", "Confidence level (1-10)", "text",
+               "For 'on a scale of 1-10, how much experience...' questions. Any number from 1 to 10."),
+            _f("Profile", "questions", "default_resume_path", "Default resume path", "text",
+               "Path to the resume file to upload, relative to the project folder, e.g. all resumes/default/resume.pdf . If the file is missing, the tool keeps your last resume on LinkedIn."),
+        ],
+    },
+    {
+        "section": "Search",
+        "fields": [
+            _f("Search", "search", "search_terms", "Search terms", "list",
+               "Job titles to search for, separated by commas, e.g. Software Engineer, Python Developer, Full Stack Developer."),
+            _f("Search", "search", "search_location", "Search location", "text",
+               "Where to look for jobs. Examples: United States, India, 'Chicago, Illinois, United States'. Leave blank to not set a location."),
+            _f("Search", "search", "switch_number", "Applications before switching term", "number",
+               "How many applications to submit for one search term before moving on to the next. A number greater than 0."),
+            _f("Search", "search", "randomize_search_order", "Randomize search order", "bool",
+               "Shuffle the order your search terms are used."),
+            _f("Search", "search", "sort_by", "Sort results by", "select",
+               "How LinkedIn should sort results. Leave blank to not change it.",
+               options=["", "Most recent", "Most relevant"]),
+            _f("Search", "search", "date_posted", "Date posted", "select",
+               "Only include jobs posted within this window. Leave blank to not filter by date.",
+               options=["", "Any time", "Past month", "Past week", "Past 24 hours"]),
+            _f("Search", "search", "salary", "Minimum salary", "select",
+               "Only include jobs at or above this salary. Leave blank to not filter by salary.",
+               options=["", "$40,000+", "$60,000+", "$80,000+", "$100,000+", "$120,000+", "$140,000+", "$160,000+", "$180,000+", "$200,000+"]),
+            _f("Search", "search", "easy_apply_only", "Easy Apply only", "bool",
+               "Only apply to jobs that use LinkedIn's Easy Apply. Recommended on."),
+            _f("Search", "search", "experience_level", "Experience level", "list",
+               "Filter by experience level, comma-separated. Valid values: Internship, Entry level, Associate, Mid-Senior level, Director, Executive. Leave blank for all."),
+            _f("Search", "search", "job_type", "Job type", "list",
+               "Filter by job type, comma-separated. Valid values: Full-time, Part-time, Contract, Temporary, Volunteer, Internship, Other. Leave blank for all."),
+            _f("Search", "search", "on_site", "On-site / Remote", "list",
+               "Filter by work setting, comma-separated. Valid values: On-site, Remote, Hybrid. Leave blank for all."),
+            _f("Search", "search", "companies", "Only these companies", "list",
+               "Only apply at these companies, comma-separated. Names must match LinkedIn exactly (including capitals). Leave blank for all companies."),
+            _f("Search", "search", "current_experience", "Your years of experience", "number",
+               "Your actual years of experience. Jobs asking for more than this are skipped. Set to -1 to ignore required experience and apply to everything."),
+            _f("Search", "search", "did_masters", "I have a master's degree", "bool",
+               "If on, jobs mentioning 'master' are still considered when their required experience is within about 2 years of yours."),
+            _f("Search", "search", "security_clearance", "I have a security clearance", "bool",
+               "Whether you hold an active security clearance."),
+            _f("Search", "search", "under_10_applicants", "Under 10 applicants only", "bool",
+               "Only apply to jobs with fewer than 10 applicants so far."),
+            _f("Search", "search", "in_your_network", "In your network only", "bool",
+               "Only apply to jobs at companies where you have a connection."),
+            _f("Search", "search", "fair_chance_employer", "Fair-chance employers only", "bool",
+               "Only apply to employers who identify as fair-chance employers."),
+        ],
+    },
+    {
+        "section": "Filters",
+        "fields": [
+            _f("Filters", "search", "about_company_bad_words", "Skip companies with these words", "list",
+               "Skip a company if any of these words appear in its 'About company' section, comma-separated. Example: Staffing, Recruiting."),
+            _f("Filters", "search", "about_company_good_words", "Keep companies with these words", "list",
+               "Exceptions to the list above: apply anyway if the 'About company' section contains one of these words, comma-separated. Example: Robert Half."),
+            _f("Filters", "search", "bad_words", "Skip jobs with these words", "list",
+               "Skip a job if any of these words or phrases appear in its description, comma-separated and case-insensitive. Example: US Citizen, No C2C, PHP."),
+        ],
+    },
+    {
+        "section": "Run settings",
+        "fields": [
+            # --- settings.py ---
+            _f("Run settings", "settings", "auto_manage_driver", "Manage Chrome driver automatically", "bool",
+               "Let the tool download and match the right Chrome driver for you. Recommended on so you don't have to install it yourself."),
+            _f("Run settings", "settings", "run_in_background", "Run in background", "bool",
+               "Hide the Chrome window while it works. Note: turning this on disables the 'pause before submit' and 'pause on hard questions' safety pauses."),
+            _f("Run settings", "settings", "safe_mode", "Safe mode", "bool",
+               "Open Chrome in a clean guest profile. Turn on if Chrome is slow to start or you have several browser profiles."),
+            _f("Run settings", "settings", "click_gap", "Pause between clicks (seconds)", "number",
+               "Roughly how many seconds to wait between actions. A whole number, e.g. 0, 1, 2."),
+            _f("Run settings", "settings", "keep_screen_awake", "Keep screen awake", "bool",
+               "Stop your computer from sleeping while the tool runs. Turn off if you'd rather manage sleep in your system settings."),
+            _f("Run settings", "settings", "close_tabs", "Close external application tabs", "bool",
+               "Close tabs opened for external (non-Easy-Apply) applications. If off, remember to close all tabs before closing the browser."),
+            _f("Run settings", "settings", "follow_companies", "Follow companies after applying", "bool",
+               "Automatically follow a company on LinkedIn after applying to it."),
+            _f("Run settings", "settings", "showAiErrorAlerts", "Show AI error alerts", "bool",
+               "Pop up an alert if there's a problem connecting to the AI service."),
+            # --- questions.py ---
+            _f("Run settings", "questions", "pause_before_submit", "Pause before submitting", "bool",
+               "Pause on the final screen of each application so you can review it before it's sent. Recommended on. Ignored when 'Run in background' is on."),
+            _f("Run settings", "questions", "pause_at_failed_question", "Pause on hard questions", "bool",
+               "Pause and wait for you when the tool can't confidently answer a question. If off, it answers randomly. Ignored when 'Run in background' is on."),
+            _f("Run settings", "questions", "overwrite_previous_answers", "Overwrite saved answers", "bool",
+               "Replace answers you've previously entered on LinkedIn with the ones configured here."),
+        ],
+    },
+]
+
+
+def iter_fields():
+    '''Yield every field dict across all sections, in order.'''
+    for section in SCHEMA:
+        for field in section["fields"]:
+            yield field
+
+
+def valid_keys():
+    '''
+    Return a mapping {config_module: {key: field}} of every editable setting.
+    Used by the API to validate and coerce incoming values and reject unknown
+    keys.
+    '''
+    mapping = {}
+    for field in iter_fields():
+        mapping.setdefault(field["config_module"], {})[field["key"]] = field
+    return mapping

--- a/modules/__deprecated__/__setup__/config.py
+++ b/modules/__deprecated__/__setup__/config.py
@@ -45,12 +45,12 @@ smooth_scroll = False              # True or False, Note: True or False are case
 # If enabled (True), the program would keep your screen active and prevent PC from sleeping. Instead you could disable this feature (set it to false) and adjust your PC sleep settings to Never Sleep or a preferred time. 
 keep_screen_awake = True           # True or False, Note: True or False are case-sensitive (Note: Will temporarily deactivate when any application dialog boxes are present (Eg: Pause before submit, Help needed for a question..))
 
-# Run in undetected mode to bypass anti-bot protections (Preview Feature, UNSTABLE. Recommended to leave it as False)
+# Automatically manage the matching Chrome driver (deprecated config file, kept for reference only).
 undetected_mode = True             # True or False, Note: True or False are case-sensitive
-# Now called as stealth_mode
+# Now called as auto_manage_driver
 
 # Use ChatGPT for resume building (Experimental Feature can break the application. Recommended to leave it as False) 
-use_resume_generator = False       # True or False, Note: True or False are case-sensitive ,   This feature may only work with 'undetected_mode' = True. As ChatGPT website is hosted by CloudFlare which is protected by Anti-bot protections!
+use_resume_generator = False       # True or False, Note: True or False are case-sensitive ,   This experimental feature may only work with 'undetected_mode' = True.
 
 
 

--- a/modules/open_chrome.py
+++ b/modules/open_chrome.py
@@ -15,9 +15,9 @@ version:    26.01.20.5.08
 '''
 
 from modules.helpers import get_default_temp_profile, make_directories
-from config.settings import run_in_background, stealth_mode, disable_extensions, safe_mode, file_name, failed_file_name, logs_folder_path, generated_resume_path
+from config.settings import run_in_background, auto_manage_driver, disable_extensions, safe_mode, file_name, failed_file_name, logs_folder_path, generated_resume_path
 from config.questions import default_resume_path
-if stealth_mode:
+if auto_manage_driver:
     import undetected_chromedriver as uc
 else: 
     from selenium import webdriver
@@ -31,7 +31,7 @@ from selenium.common.exceptions import SessionNotCreatedException
 def createChromeSession(isRetry: bool = False):
     make_directories([file_name,failed_file_name,logs_folder_path+"/screenshots",default_resume_path,generated_resume_path+"/temp"])
     # Set up WebDriver with Chrome Profile
-    options = uc.ChromeOptions() if stealth_mode else Options()
+    options = uc.ChromeOptions() if auto_manage_driver else Options()
     if run_in_background:   options.add_argument("--headless")
     if disable_extensions:  options.add_argument("--disable-extensions")
 
@@ -44,12 +44,12 @@ def createChromeSession(isRetry: bool = False):
     else:
         print_lg("Logging in with a guest profile, Web history will not be saved!")
         options.add_argument(f"--user-data-dir={get_default_temp_profile()}")
-    if stealth_mode:
+    if auto_manage_driver:
         # try: 
         #     driver = uc.Chrome(driver_executable_path="C:\\Program Files\\Google\\Chrome\\chromedriver-win64\\chromedriver.exe", options=options)
         # except (FileNotFoundError, PermissionError) as e: 
-        #     print_lg("(Undetected Mode) Got '{}' when using pre-installed ChromeDriver.".format(type(e).__name__)) 
-            print_lg("Downloading Chrome Driver... This may take some time. Undetected mode requires download every run!")
+        #     print_lg("(auto-managed driver) Got '{}' when using pre-installed ChromeDriver.".format(type(e).__name__))
+            print_lg("Downloading the matching Chrome driver... This may take some time (this happens each run when auto_manage_driver is enabled).")
             driver = uc.Chrome(options=options)
     else: driver = webdriver.Chrome(options=options) #, service=Service(executable_path="C:\\Program Files\\Google\\Chrome\\chromedriver-win64\\chromedriver.exe"))
     driver.maximize_window()
@@ -65,7 +65,7 @@ except SessionNotCreatedException as e:
     options, driver, actions, wait = createChromeSession(True)
 except Exception as e:
     msg = 'Seems like Google Chrome is out dated. Update browser and try again! \n\n\nIf issue persists, try Safe Mode. Set, safe_mode = True in config.py \n\nPlease check GitHub discussions/support for solutions https://github.com/GodsScion/Auto_job_applier_linkedIn \n                                   OR \nReach out in discord ( https://discord.gg/fFp7uUzWCY )'
-    if isinstance(e,TimeoutError): msg = "Couldn't download Chrome-driver. Set stealth_mode = False in config!"
+    if isinstance(e,TimeoutError): msg = "Couldn't download Chrome-driver. Set auto_manage_driver = False in config!"
     print_lg(msg)
     critical_error_log("In Opening Chrome", e)
     from pyautogui import alert

--- a/modules/validator.py
+++ b/modules/validator.py
@@ -213,7 +213,7 @@ def validate_settings() -> None | ValueError | TypeError:
     check_boolean(safe_mode, "safe_mode")
     check_boolean(smooth_scroll, "smooth_scroll")
     check_boolean(keep_screen_awake, "keep_screen_awake")
-    check_boolean(stealth_mode, "stealth_mode")
+    check_boolean(auto_manage_driver, "auto_manage_driver")
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,22 @@
+# Auto Job Applier — Python dependencies
+# Install everything with:  pip install -r requirements.txt
+
+# Browser automation
+selenium
+undetected-chromedriver          # auto-downloads a matching Chrome driver (auto_manage_driver = True)
+setuptools                       # required by undetected-chromedriver on some Python versions
+
+# Desktop dialogs / prompts
+pyautogui
+
+# AI providers (for resume tailoring, cover letters, and question answering)
+openai                           # OpenAI, DeepSeek, and other OpenAI-compatible APIs
+google-generativeai              # Google Gemini
+
+# Resume / document generation
+fpdf2                            # PDF output (imported as `fpdf`)
+python-docx                      # .docx output (imported as `docx`)
+
+# Local applied-jobs history web UI (app.py)
+flask
+flask-cors

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,75 @@
+@echo off
+REM
+REM Author:  Sai Vignesh Golla
+REM License: GNU Affero General Public License
+REM          https://www.gnu.org/licenses/agpl-3.0.en.html
+REM GitHub:  https://github.com/GodsScion/Auto_job_applier_linkedIn
+REM
+REM One-click launcher for Windows. Double-click this file. It sets up everything
+REM the first time, then opens the control panel in your web browser. Safe to run
+REM again any time.
+
+setlocal
+cd /d "%~dp0"
+
+echo.
+echo ========================================================
+echo   Auto Job Applier - starting your control panel
+echo ========================================================
+echo.
+
+REM 1) Find Python (prefer the "py" launcher, fall back to "python").
+set "PYLAUNCH="
+py -3 --version >nul 2>&1 && set "PYLAUNCH=py -3"
+if not defined PYLAUNCH (
+    python --version >nul 2>&1 && set "PYLAUNCH=python"
+)
+if not defined PYLAUNCH (
+    echo Python was not found on this computer.
+    echo Please install it from https://www.python.org/downloads/ or the Microsoft Store,
+    echo make sure "Add Python to PATH" is checked, then run this again.
+    echo.
+    pause
+    exit /b 1
+)
+
+set "VENV_PY=.venv\Scripts\python.exe"
+
+REM 2) Create a private Python environment the first time.
+if not exist "%VENV_PY%" (
+    echo Setting up for the first time (this can take a minute)...
+    %PYLAUNCH% -m venv .venv
+    if errorlevel 1 (
+        echo Could not create the Python environment.
+        pause
+        exit /b 1
+    )
+)
+
+REM 3) Install the required packages once (quietly).
+if not exist ".venv\.deps_installed" (
+    echo Installing required packages (one time only)...
+    "%VENV_PY%" -m pip install --quiet --upgrade pip
+    "%VENV_PY%" -m pip install --quiet -r requirements.txt
+    if errorlevel 1 (
+        echo Could not install required packages.
+        pause
+        exit /b 1
+    )
+    echo done> ".venv\.deps_installed"
+)
+
+REM 4) Open the browser shortly after the server starts.
+start "" cmd /c "timeout /t 2 /nobreak >nul & start "" http://127.0.0.1:5000"
+
+echo.
+echo Opening the control panel in your browser at http://127.0.0.1:5000
+echo Keep this window open while you use the tool. Close it to stop the server.
+echo.
+
+REM 5) Start the local control panel (runs until you close this window).
+"%VENV_PY%" app.py
+
+echo.
+echo The control panel has stopped.
+pause

--- a/start.command
+++ b/start.command
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Author:  Sai Vignesh Golla
+# License: GNU Affero General Public License
+#          https://www.gnu.org/licenses/agpl-3.0.en.html
+# GitHub:  https://github.com/GodsScion/Auto_job_applier_linkedIn
+#
+# One-click launcher for macOS. Double-click this file in Finder (or run it from
+# a terminal). It sets up everything the first time, then opens the control
+# panel in your web browser. Safe to run again any time.
+
+# Move into the project folder (this script's own folder).
+cd "$(dirname "$0")" || exit 1
+
+echo ""
+echo "========================================================"
+echo "  Auto Job Applier - starting your control panel"
+echo "========================================================"
+echo ""
+
+# 1) Make sure Python 3 is installed.
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Python 3 was not found on this computer."
+    echo "Please install it from https://www.python.org/downloads/ and run this again."
+    echo ""
+    read -r -p "Press Return to close..." _
+    exit 1
+fi
+
+VENV_PY=".venv/bin/python"
+
+# 2) Create a private Python environment the first time.
+if [ ! -x "$VENV_PY" ]; then
+    echo "Setting up for the first time (this can take a minute)..."
+    python3 -m venv .venv || { echo "Could not create the Python environment."; read -r -p "Press Return to close..." _; exit 1; }
+fi
+
+# 3) Install the required packages once (quietly).
+if [ ! -f ".venv/.deps_installed" ]; then
+    echo "Installing required packages (one time only)..."
+    "$VENV_PY" -m pip install --quiet --upgrade pip
+    "$VENV_PY" -m pip install --quiet -r requirements.txt || { echo "Could not install required packages."; read -r -p "Press Return to close..." _; exit 1; }
+    touch ".venv/.deps_installed"
+fi
+
+# 4) Open the browser shortly after the server starts.
+( sleep 2; open "http://127.0.0.1:5000" >/dev/null 2>&1 ) &
+
+echo ""
+echo "Opening the control panel in your browser at http://127.0.0.1:5000"
+echo "Keep this window open while you use the tool. Close it to stop the server."
+echo ""
+
+# 5) Start the local control panel (runs until you close this window).
+"$VENV_PY" app.py
+
+echo ""
+read -r -p "The control panel has stopped. Press Return to close..." _

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Author:  Sai Vignesh Golla
+# License: GNU Affero General Public License
+#          https://www.gnu.org/licenses/agpl-3.0.en.html
+# GitHub:  https://github.com/GodsScion/Auto_job_applier_linkedIn
+#
+# One-click launcher for Linux. Run it with:  ./start.sh
+# It sets up everything the first time, then opens the control panel in your web
+# browser. Safe to run again any time.
+
+# Move into the project folder (this script's own folder).
+cd "$(dirname "$0")" || exit 1
+
+echo ""
+echo "========================================================"
+echo "  Auto Job Applier - starting your control panel"
+echo "========================================================"
+echo ""
+
+# 1) Make sure Python 3 is installed.
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Python 3 was not found on this computer."
+    echo "Please install it (e.g. 'sudo apt install python3 python3-venv') and run this again."
+    exit 1
+fi
+
+VENV_PY=".venv/bin/python"
+
+# 2) Create a private Python environment the first time.
+if [ ! -x "$VENV_PY" ]; then
+    echo "Setting up for the first time (this can take a minute)..."
+    python3 -m venv .venv || { echo "Could not create the Python environment. You may need the 'python3-venv' package."; exit 1; }
+fi
+
+# 3) Install the required packages once (quietly).
+if [ ! -f ".venv/.deps_installed" ]; then
+    echo "Installing required packages (one time only)..."
+    "$VENV_PY" -m pip install --quiet --upgrade pip
+    "$VENV_PY" -m pip install --quiet -r requirements.txt || { echo "Could not install required packages."; exit 1; }
+    touch ".venv/.deps_installed"
+fi
+
+# 4) Open the browser shortly after the server starts (if a browser opener exists).
+if command -v xdg-open >/dev/null 2>&1; then
+    ( sleep 2; xdg-open "http://127.0.0.1:5000" >/dev/null 2>&1 ) &
+fi
+
+echo ""
+echo "Open the control panel in your browser at http://127.0.0.1:5000"
+echo "Keep this terminal open while you use the tool. Press Ctrl+C to stop the server."
+echo ""
+
+# 5) Start the local control panel (runs until you press Ctrl+C).
+"$VENV_PY" app.py

--- a/templates/control_panel.html
+++ b/templates/control_panel.html
@@ -1,0 +1,608 @@
+<!--
+  Author:  Sai Vignesh Golla
+  License: GNU Affero General Public License
+           https://www.gnu.org/licenses/agpl-3.0.en.html
+  GitHub:  https://github.com/GodsScion/Auto_job_applier_linkedIn
+
+  Local control panel for the Auto Job Applier. Vanilla HTML/CSS/JS only, no
+  external libraries or network calls, works fully offline. It reads and writes
+  only user_config.json (via the API in app.py) and never edits the config/*.py
+  files.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Auto Job Applier - Control Panel</title>
+    <style>
+        :root {
+            --bg: #f4f6f9;
+            --card: #ffffff;
+            --ink: #1f2733;
+            --muted: #6b7684;
+            --line: #dce1e8;
+            --brand: #2563eb;
+            --brand-dark: #1d4ed8;
+            --ok: #16a34a;
+            --warn: #b45309;
+            --danger: #dc2626;
+            --shadow: 0 1px 3px rgba(16,24,40,.08), 0 1px 2px rgba(16,24,40,.06);
+        }
+        * { box-sizing: border-box; }
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            background: var(--bg);
+            color: var(--ink);
+            line-height: 1.5;
+        }
+        header {
+            background: var(--card);
+            border-bottom: 1px solid var(--line);
+            padding: 20px 24px;
+        }
+        header h1 { margin: 0 0 4px; font-size: 20px; }
+        header p { margin: 0; color: var(--muted); font-size: 14px; }
+        .wrap { max-width: 900px; margin: 0 auto; padding: 0 16px; }
+        nav {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+            background: var(--card);
+            border-bottom: 1px solid var(--line);
+            position: sticky;
+            top: 0;
+            z-index: 5;
+        }
+        nav button {
+            background: none;
+            border: none;
+            border-bottom: 3px solid transparent;
+            padding: 12px 16px;
+            font-size: 14px;
+            font-weight: 600;
+            color: var(--muted);
+            cursor: pointer;
+        }
+        nav button:hover { color: var(--ink); }
+        nav button.active { color: var(--brand); border-bottom-color: var(--brand); }
+        main { padding: 24px 0 80px; }
+        .panel { display: none; }
+        .panel.active { display: block; }
+        .field {
+            background: var(--card);
+            border: 1px solid var(--line);
+            border-radius: 10px;
+            padding: 14px 16px;
+            margin-bottom: 12px;
+            box-shadow: var(--shadow);
+        }
+        .field label { display: block; font-weight: 600; margin-bottom: 4px; font-size: 14px; }
+        .field .help { color: var(--muted); font-size: 13px; margin: 0 0 8px; }
+        .field input[type=text],
+        .field input[type=password],
+        .field input[type=number],
+        .field select,
+        .field textarea {
+            width: 100%;
+            padding: 9px 11px;
+            border: 1px solid var(--line);
+            border-radius: 8px;
+            font-size: 14px;
+            font-family: inherit;
+            background: #fff;
+            color: var(--ink);
+        }
+        .field textarea { min-height: 90px; resize: vertical; }
+        .field input:focus, .field select:focus, .field textarea:focus {
+            outline: none;
+            border-color: var(--brand);
+            box-shadow: 0 0 0 3px rgba(37,99,235,.15);
+        }
+        .checkline { display: flex; align-items: center; gap: 10px; }
+        .checkline input[type=checkbox] { width: 20px; height: 20px; accent-color: var(--brand); }
+        .checkline label { margin: 0; }
+        .savebar {
+            position: fixed;
+            bottom: 0; left: 0; right: 0;
+            background: var(--card);
+            border-top: 1px solid var(--line);
+            padding: 12px 16px;
+            display: flex;
+            align-items: center;
+            gap: 14px;
+            justify-content: flex-end;
+            box-shadow: 0 -1px 3px rgba(16,24,40,.06);
+        }
+        .savebar .msg { margin-right: auto; font-size: 14px; color: var(--muted); }
+        .savebar .msg.ok { color: var(--ok); }
+        .savebar .msg.err { color: var(--danger); }
+        button.btn {
+            background: var(--brand);
+            color: #fff;
+            border: none;
+            border-radius: 8px;
+            padding: 10px 18px;
+            font-size: 14px;
+            font-weight: 600;
+            cursor: pointer;
+        }
+        button.btn:hover { background: var(--brand-dark); }
+        button.btn:disabled { background: #9db4e8; cursor: not-allowed; }
+        button.btn.secondary { background: #eef1f6; color: var(--ink); }
+        button.btn.secondary:hover { background: #e2e7ef; }
+        button.btn.danger { background: var(--danger); }
+        button.btn.danger:hover { background: #b91c1c; }
+        .note {
+            background: #eff6ff;
+            border: 1px solid #bfdbfe;
+            color: #1e40af;
+            border-radius: 10px;
+            padding: 14px 16px;
+            font-size: 14px;
+            margin-bottom: 16px;
+        }
+        .runbox {
+            background: var(--card);
+            border: 1px solid var(--line);
+            border-radius: 10px;
+            padding: 16px;
+            margin-bottom: 16px;
+            box-shadow: var(--shadow);
+        }
+        .status-line { display: flex; align-items: center; gap: 10px; margin-bottom: 14px; font-weight: 600; }
+        .dot { width: 12px; height: 12px; border-radius: 50%; background: #cbd2dc; }
+        .dot.on { background: var(--ok); box-shadow: 0 0 0 4px rgba(22,163,74,.15); }
+        .run-actions { display: flex; gap: 10px; margin-bottom: 8px; }
+        pre.log {
+            background: #0f172a;
+            color: #e2e8f0;
+            border-radius: 10px;
+            padding: 14px;
+            font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+            font-size: 12.5px;
+            line-height: 1.5;
+            max-height: 340px;
+            overflow: auto;
+            white-space: pre-wrap;
+            word-break: break-word;
+            margin: 0;
+        }
+        h2.section-h { font-size: 16px; margin: 4px 0 14px; }
+        table.jobs { border-collapse: collapse; width: 100%; font-size: 13px; }
+        table.jobs th, table.jobs td { border: 1px solid var(--line); padding: 8px 10px; text-align: left; vertical-align: top; }
+        table.jobs th { background: #f1f4f8; font-weight: 600; }
+        table.jobs tr:nth-child(even) { background: #fafbfc; }
+        table.jobs a { color: var(--brand); text-decoration: none; }
+        table.jobs a:hover { text-decoration: underline; }
+        .tick { color: var(--ok); font-weight: 700; }
+        .muted-small { color: var(--muted); font-size: 13px; }
+        @media (max-width: 560px) {
+            nav button { padding: 10px 10px; font-size: 13px; }
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="wrap">
+            <h1>Auto Job Applier - Control Panel</h1>
+            <p>Set up everything here, then open the Run tab to start. Nothing is uploaded - your details are saved only on this computer.</p>
+        </div>
+    </header>
+
+    <nav id="tabs" class="wrap"></nav>
+
+    <main class="wrap">
+        <div id="panels"></div>
+    </main>
+
+    <div class="savebar" id="savebar">
+        <span class="msg" id="saveMsg">Make your changes across the tabs, then click Save.</span>
+        <button class="btn secondary" id="reloadBtn" type="button">Reload</button>
+        <button class="btn" id="saveBtn" type="button">Save</button>
+    </div>
+
+    <script>
+        // ---- state ----
+        var SCHEMA = [];
+        var CONFIG = {};        // {config_module: {key: value}}
+        var BASELINE = {};      // JSON snapshot for change detection
+        var activeTab = null;
+        var logOffset = 0;
+        var pollTimer = null;
+
+        // ---- helpers ----
+        function el(tag, attrs, children) {
+            var node = document.createElement(tag);
+            if (attrs) {
+                for (var k in attrs) {
+                    if (k === 'text') { node.textContent = attrs[k]; }
+                    else if (k === 'html') { node.innerHTML = attrs[k]; }
+                    else { node.setAttribute(k, attrs[k]); }
+                }
+            }
+            (children || []).forEach(function (c) { if (c) node.appendChild(c); });
+            return node;
+        }
+
+        function fieldId(field) { return 'f__' + field.config_module + '__' + field.key; }
+
+        function currentValue(cm, key) {
+            if (CONFIG[cm] && Object.prototype.hasOwnProperty.call(CONFIG[cm], key)) {
+                return CONFIG[cm][key];
+            }
+            return '';
+        }
+
+        // ---- rendering ----
+        function renderControl(field) {
+            var value = currentValue(field.config_module, field.key);
+            var id = fieldId(field);
+            var control;
+            if (field.type === 'bool') {
+                control = el('input', { type: 'checkbox', id: id });
+                if (value === true) control.checked = true;
+            } else if (field.type === 'textarea') {
+                control = el('textarea', { id: id });
+                control.value = (value === null || value === undefined) ? '' : String(value);
+            } else if (field.type === 'select') {
+                control = el('select', { id: id });
+                (field.options || []).forEach(function (opt) {
+                    var o = el('option', { value: opt, text: opt === '' ? '(leave unanswered)' : opt });
+                    if (String(value) === String(opt)) o.selected = true;
+                    control.appendChild(o);
+                });
+            } else if (field.type === 'list') {
+                control = el('input', { type: 'text', id: id });
+                control.value = Array.isArray(value) ? value.join(', ') : (value || '');
+            } else if (field.type === 'number') {
+                control = el('input', { type: 'number', id: id, step: 'any' });
+                control.value = (value === null || value === undefined) ? '' : String(value);
+            } else {
+                var t = field.type === 'password' ? 'password' : 'text';
+                control = el('input', { type: t, id: id });
+                control.value = (value === null || value === undefined) ? '' : String(value);
+            }
+            return control;
+        }
+
+        function renderField(field) {
+            var control = renderControl(field);
+            var box = el('div', { class: 'field' });
+            if (field.type === 'bool') {
+                var line = el('div', { class: 'checkline' });
+                line.appendChild(control);
+                line.appendChild(el('label', { for: fieldId(field), text: field.label }));
+                box.appendChild(line);
+                if (field.help) box.appendChild(el('p', { class: 'help', text: field.help }));
+            } else {
+                box.appendChild(el('label', { for: fieldId(field), text: field.label }));
+                if (field.help) box.appendChild(el('p', { class: 'help', text: field.help }));
+                box.appendChild(control);
+            }
+            return box;
+        }
+
+        function buildTabs() {
+            var tabs = document.getElementById('tabs');
+            var panels = document.getElementById('panels');
+            tabs.innerHTML = '';
+            panels.innerHTML = '';
+
+            SCHEMA.forEach(function (section) {
+                var btn = el('button', { type: 'button', text: section.section });
+                btn.addEventListener('click', function () { showTab(section.section); });
+                btn.dataset.tab = section.section;
+                tabs.appendChild(btn);
+
+                var panel = el('div', { class: 'panel' });
+                panel.dataset.tab = section.section;
+                section.fields.forEach(function (field) { panel.appendChild(renderField(field)); });
+                panels.appendChild(panel);
+            });
+
+            // Extra "Run" tab (not part of the config schema).
+            var runBtn = el('button', { type: 'button', text: 'Run' });
+            runBtn.dataset.tab = 'Run';
+            runBtn.addEventListener('click', function () { showTab('Run'); });
+            tabs.appendChild(runBtn);
+            panels.appendChild(buildRunPanel());
+
+            showTab(SCHEMA.length ? SCHEMA[0].section : 'Run');
+        }
+
+        function showTab(name) {
+            activeTab = name;
+            document.querySelectorAll('#tabs button').forEach(function (b) {
+                b.classList.toggle('active', b.dataset.tab === name);
+            });
+            document.querySelectorAll('#panels .panel').forEach(function (p) {
+                p.classList.toggle('active', p.dataset.tab === name);
+            });
+            var isRun = (name === 'Run');
+            document.getElementById('savebar').style.display = isRun ? 'none' : 'flex';
+            if (isRun) { refreshStatus(); refreshLogs(); loadAppliedJobs(); }
+        }
+
+        // ---- Run tab ----
+        function buildRunPanel() {
+            var panel = el('div', { class: 'panel' });
+            panel.dataset.tab = 'Run';
+
+            panel.appendChild(el('div', { class: 'note', html:
+                'This runs on <strong>your computer</strong> using <strong>your own LinkedIn account</strong>. ' +
+                'When you press Start, a browser window will open - keep it in the foreground and let it work. ' +
+                'You can watch progress in the log below and stop at any time.' }));
+
+            var runbox = el('div', { class: 'runbox' });
+            var statusLine = el('div', { class: 'status-line' });
+            statusLine.appendChild(el('span', { class: 'dot', id: 'statusDot' }));
+            statusLine.appendChild(el('span', { id: 'statusText', text: 'Checking status...' }));
+            runbox.appendChild(statusLine);
+
+            var actions = el('div', { class: 'run-actions' });
+            var startBtn = el('button', { class: 'btn', id: 'startBtn', type: 'button', text: 'Start' });
+            var stopBtn = el('button', { class: 'btn danger', id: 'stopBtn', type: 'button', text: 'Stop' });
+            startBtn.addEventListener('click', startBot);
+            stopBtn.addEventListener('click', stopBot);
+            actions.appendChild(startBtn);
+            actions.appendChild(stopBtn);
+            runbox.appendChild(actions);
+            runbox.appendChild(el('p', { class: 'muted-small',
+                text: 'Tip: save your settings on the other tabs before starting.' }));
+            panel.appendChild(runbox);
+
+            panel.appendChild(el('h2', { class: 'section-h', text: 'Activity log' }));
+            panel.appendChild(el('pre', { class: 'log', id: 'logPane', text: 'No activity yet.' }));
+
+            var histWrap = el('div', {});
+            histWrap.appendChild(el('h2', { class: 'section-h', text: 'Applied jobs history' }));
+            var refresh = el('button', { class: 'btn secondary', type: 'button', text: 'Refresh history' });
+            refresh.addEventListener('click', loadAppliedJobs);
+            histWrap.appendChild(refresh);
+            var tableHolder = el('div', { id: 'jobsHolder', style: 'overflow-x:auto; margin-top:12px;' });
+            tableHolder.appendChild(el('p', { class: 'muted-small', text: 'Loading history...' }));
+            histWrap.appendChild(tableHolder);
+            panel.appendChild(histWrap);
+
+            return panel;
+        }
+
+        function setRunningUI(running, pid) {
+            var dot = document.getElementById('statusDot');
+            var text = document.getElementById('statusText');
+            var startBtn = document.getElementById('startBtn');
+            var stopBtn = document.getElementById('stopBtn');
+            if (!dot) return;
+            if (running) {
+                dot.classList.add('on');
+                text.textContent = 'Running' + (pid ? ' (process ' + pid + ')' : '') + '...';
+                if (startBtn) startBtn.disabled = true;
+                if (stopBtn) stopBtn.disabled = false;
+            } else {
+                dot.classList.remove('on');
+                text.textContent = 'Not running';
+                if (startBtn) startBtn.disabled = false;
+                if (stopBtn) stopBtn.disabled = true;
+            }
+        }
+
+        function refreshStatus() {
+            fetch('/api/status').then(function (r) { return r.json(); })
+                .then(function (s) { setRunningUI(s.running, s.pid); })
+                .catch(function () {});
+        }
+
+        function refreshLogs() {
+            fetch('/api/logs?offset=' + logOffset).then(function (r) { return r.json(); })
+                .then(function (data) {
+                    if (typeof data.next_offset === 'number' && data.next_offset < logOffset) {
+                        // Log was truncated; reset the pane.
+                        logOffset = 0;
+                        document.getElementById('logPane').textContent = '';
+                    }
+                    if (data.content) {
+                        var pane = document.getElementById('logPane');
+                        if (pane.textContent === 'No activity yet.') pane.textContent = '';
+                        var atBottom = pane.scrollTop + pane.clientHeight >= pane.scrollHeight - 20;
+                        pane.textContent += data.content;
+                        if (atBottom) pane.scrollTop = pane.scrollHeight;
+                    }
+                    if (typeof data.next_offset === 'number') logOffset = data.next_offset;
+                })
+                .catch(function () {});
+        }
+
+        function startBot() {
+            var msgOk = confirm('Start applying now?\n\nA browser window will open and use your LinkedIn account. Keep it in the foreground.');
+            if (!msgOk) return;
+            var pane = document.getElementById('logPane');
+            pane.textContent = '';
+            logOffset = 0;
+            fetch('/api/run', { method: 'POST' }).then(function (r) { return r.json(); })
+                .then(function (s) { setRunningUI(s.running, s.pid); refreshLogs(); })
+                .catch(function () {});
+        }
+
+        function stopBot() {
+            fetch('/api/stop', { method: 'POST' }).then(function (r) { return r.json(); })
+                .then(function (s) { setRunningUI(s.running, s.pid); })
+                .catch(function () {});
+        }
+
+        function pollLoop() {
+            if (activeTab === 'Run') { refreshStatus(); refreshLogs(); }
+            pollTimer = setTimeout(pollLoop, 1500);
+        }
+
+        // ---- applied jobs history ----
+        function loadAppliedJobs() {
+            var holder = document.getElementById('jobsHolder');
+            if (!holder) return;
+            fetch('/applied-jobs').then(function (r) {
+                if (r.status === 404) return [];
+                return r.json();
+            }).then(function (jobs) {
+                if (!Array.isArray(jobs) || jobs.length === 0) {
+                    holder.innerHTML = '';
+                    holder.appendChild(el('p', { class: 'muted-small', text: 'No applications yet. They will appear here after your first run.' }));
+                    return;
+                }
+                var table = el('table', { class: 'jobs' });
+                var thead = el('thead');
+                var hr = el('tr');
+                ['#', 'Job Title', 'Company', 'HR Contact', 'Link', 'Applied'].forEach(function (h) {
+                    hr.appendChild(el('th', { text: h }));
+                });
+                thead.appendChild(hr);
+                table.appendChild(thead);
+                var tbody = el('tbody');
+                jobs.forEach(function (job, i) {
+                    var tr = el('tr');
+                    tr.appendChild(el('td', { text: String(i + 1) }));
+                    var titleCell = el('td');
+                    if (job.Job_Link) {
+                        titleCell.appendChild(el('a', { href: job.Job_Link, target: '_blank', rel: 'noopener', text: job.Title || 'View' }));
+                    } else { titleCell.textContent = job.Title || ''; }
+                    tr.appendChild(titleCell);
+                    tr.appendChild(el('td', { text: job.Company || '' }));
+                    var hrCell = el('td');
+                    if (job.HR_Name && job.HR_Name !== 'Unknown' && job.HR_Link) {
+                        hrCell.appendChild(el('a', { href: job.HR_Link, target: '_blank', rel: 'noopener', text: job.HR_Name }));
+                    } else { hrCell.textContent = 'N/A'; }
+                    tr.appendChild(hrCell);
+                    var linkCell = el('td');
+                    if (job.External_Job_link === 'Easy Applied') {
+                        linkCell.textContent = 'Easy Applied';
+                    } else if (job.External_Job_link) {
+                        linkCell.appendChild(el('a', { href: job.External_Job_link, target: '_blank', rel: 'noopener', text: 'External' }));
+                    } else { linkCell.textContent = 'N/A'; }
+                    tr.appendChild(linkCell);
+                    var appliedCell = el('td');
+                    if (job.External_Job_link === 'Easy Applied' || (job.Date_Applied && job.Date_Applied !== 'Pending')) {
+                        appliedCell.innerHTML = '<span class="tick">&#10003;</span>';
+                    }
+                    tr.appendChild(appliedCell);
+                    tbody.appendChild(tr);
+                });
+                table.appendChild(tbody);
+                holder.innerHTML = '';
+                holder.appendChild(table);
+            }).catch(function () {
+                holder.innerHTML = '';
+                holder.appendChild(el('p', { class: 'muted-small', text: 'Could not load history.' }));
+            });
+        }
+
+        // ---- save / load config ----
+        function readControlValue(field) {
+            var node = document.getElementById(fieldId(field));
+            if (!node) return undefined;
+            if (field.type === 'bool') return node.checked;
+            if (field.type === 'list') {
+                return node.value.split(',').map(function (s) { return s.trim(); })
+                    .filter(function (s) { return s !== ''; });
+            }
+            if (field.type === 'number') {
+                var t = node.value.trim();
+                if (t === '') return undefined; // leave unchanged, avoid server error
+                var n = Number(t);
+                return isNaN(n) ? undefined : n;
+            }
+            return node.value;
+        }
+
+        function baselineValue(cm, key) {
+            if (BASELINE[cm] && Object.prototype.hasOwnProperty.call(BASELINE[cm], key)) {
+                return BASELINE[cm][key];
+            }
+            return undefined;
+        }
+
+        function saveConfig() {
+            var payload = {};
+            var changed = 0;
+            SCHEMA.forEach(function (section) {
+                section.fields.forEach(function (field) {
+                    var current = readControlValue(field);
+                    if (current === undefined) return;
+                    var base = baselineValue(field.config_module, field.key);
+                    if (JSON.stringify(current) !== JSON.stringify(base)) {
+                        if (!payload[field.config_module]) payload[field.config_module] = {};
+                        payload[field.config_module][field.key] = current;
+                        changed++;
+                    }
+                });
+            });
+
+            var msg = document.getElementById('saveMsg');
+            if (changed === 0) {
+                msg.className = 'msg';
+                msg.textContent = 'Nothing to save - no changes yet.';
+                return;
+            }
+            var btn = document.getElementById('saveBtn');
+            btn.disabled = true;
+            msg.className = 'msg';
+            msg.textContent = 'Saving...';
+            fetch('/api/config', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            }).then(function (r) {
+                return r.json().then(function (body) { return { ok: r.ok, body: body }; });
+            }).then(function (res) {
+                btn.disabled = false;
+                if (!res.ok) {
+                    msg.className = 'msg err';
+                    msg.textContent = 'Could not save: ' + (res.body && res.body.error ? res.body.error : 'unknown error');
+                    return;
+                }
+                CONFIG = mergeIntoConfig(res.body);
+                BASELINE = JSON.parse(JSON.stringify(CONFIG));
+                msg.className = 'msg ok';
+                msg.textContent = 'Saved ' + changed + (changed === 1 ? ' change.' : ' changes.');
+            }).catch(function (err) {
+                btn.disabled = false;
+                msg.className = 'msg err';
+                msg.textContent = 'Could not save: ' + err;
+            });
+        }
+
+        function mergeIntoConfig(saved) {
+            // saved is the full user_config.json. Overlay it onto the effective CONFIG.
+            var merged = JSON.parse(JSON.stringify(CONFIG));
+            for (var cm in saved) {
+                if (!merged[cm]) merged[cm] = {};
+                for (var key in saved[cm]) { merged[cm][key] = saved[cm][key]; }
+            }
+            return merged;
+        }
+
+        function loadAll() {
+            Promise.all([
+                fetch('/api/schema').then(function (r) { return r.json(); }),
+                fetch('/api/config').then(function (r) { return r.json(); })
+            ]).then(function (results) {
+                SCHEMA = results[0];
+                CONFIG = results[1] || {};
+                BASELINE = JSON.parse(JSON.stringify(CONFIG));
+                buildTabs();
+            }).catch(function (err) {
+                document.getElementById('panels').innerHTML =
+                    '<p style="color:#dc2626">Could not load settings from the app. Is it still running? (' + err + ')</p>';
+            });
+        }
+
+        document.getElementById('saveBtn').addEventListener('click', saveConfig);
+        document.getElementById('reloadBtn').addEventListener('click', function () {
+            document.getElementById('saveMsg').textContent = 'Reloading saved settings...';
+            loadAll();
+        });
+
+        loadAll();
+        pollLoop();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## What this does

Adds a local web **control panel** so a non-technical person can configure and run the tool from their browser instead of editing Python files and using a terminal, plus **one-click launcher scripts**.

- **`config_schema.py`** - single source of truth describing every editable setting, grouped into tabs (Account, Profile, Search, Filters, Run settings). Each field knows its `config_module` (which is also its `user_config.json` section), type, label, help text (drawn from the existing config comments) and select options.
- **`app.py`** (extended, all existing endpoints preserved) - new endpoints:
  - `GET /` renders the control panel; `GET /history` keeps the original applied-jobs page reachable (it is also embedded as a tab in the Run view).
  - `GET /api/schema` - the field schema.
  - `GET /api/config` - pristine config defaults overlaid with the current `user_config.json` (re-read each call), grouped by config module.
  - `POST /api/config` - validates against the schema, coerces types, **rejects unknown keys**, and merges into `user_config.json` (read-modify-write).
  - `POST /api/run` / `POST /api/stop` / `GET /api/status` / `GET /api/logs?offset=N` - start/stop `runAiBot.py` as a subprocess, track liveness, stream the run log.
- **`templates/control_panel.html`** - single-page UI, **vanilla HTML/CSS/JS only** (no CDNs, no build step, works offline). Forms render from the schema + config; Save posts only changed values. The Run tab has Start/Stop, live status, a polled activity log, and the applied-jobs history table, with friendly non-technical copy.
- **Launchers** - `start.command` (macOS), `start.sh` (Linux), `start.bat` (Windows). Each is idempotent: checks for Python, creates `.venv` if missing, installs `requirements.txt` once (quietly), launches `app.py`, and opens the browser to `http://127.0.0.1:5000`.
- **README** - new "Easy start (recommended)" section near the top of the install area; existing manual instructions kept below.

## Non-breaking guarantee

The UI reads and writes **only `user_config.json`** (already gitignored) and never edits the `config/*.py` files. The config modules apply that file over their built-in defaults via the existing `config/_overrides.py` hook. **With no `user_config.json` present, the tool behaves exactly as before.** Verified: writing `{"search":{"search_location":"QA City"}}` makes `config.search.search_location` return `"QA City"`; removing the file returns it to the default `"United States"`.

## Security

- `app.run(host="127.0.0.1", port=5000, debug=False)` - **localhost-only, debug off**. Never binds `0.0.0.0`.
- Credentials/answers are stored only in `user_config.json` on the user's own machine (gitignored) - never in tracked files, never uploaded.

## What was tested here

- `python3 -m compileall -q .` passes (the lone `SyntaxWarning` is pre-existing in `runAiBot.py`).
- Override round-trip via the real config module (see above).
- Booted `app.py` on `127.0.0.1`: `GET /api/schema` (5 tabs, 68 fields), `GET /api/config` (defaults), `POST /api/config` round-trip confirmed by a follow-up `GET`, unknown-key POST rejected with **HTTP 400**, and type coercion (`"true"`->`True`, `"3"`->`3`, `"A, B , ,C"`->`["A","B","C"]`).
- `git check-ignore` confirms `user_config.json`, `.bot_run.log`, `.bot_run.pid`, `.venv` are all ignored; none are committed.
- Run/stop plumbing validated **without the real bot** by pointing the subprocess helper at a harmless sleep-and-print: `/api/status` flips `true`->`false`, `/api/logs` captured the output, `/api/stop` terminated it (and removed the PID file), and a short process was seen going `true`->`false` on natural exit.

## What could NOT be tested here

A real end-to-end job-application run was **not** performed. That requires the user's own Chrome browser and a live LinkedIn login, which are not available in this environment. The subprocess wiring is exercised with a stand-in command; the actual `runAiBot.py` LinkedIn automation is unchanged by this PR.
