### PR TITLE
Fix return-in-finally warning and latent UnboundLocalError in get_job_description

### DIFF
--- a/runAiBot.py
+++ b/runAiBot.py
@@ -382,17 +382,19 @@ def get_job_description(
     - `skipReason: str | None`
     - `skipMessage: str | None`
     '''
+    # Initialise every return value before the try, so an early failure (e.g. the
+    # description element not being found) can never leave them unbound.
+    ##> ------ Dheeraj Deshwal : dheeraj9811 Email:dheeraj20194@iiitd.ac.in/dheerajdeshwal9811@gmail.com - Feature ------
+    jobDescription = "Unknown"
+    ##<
+    experience_required = "Unknown"
+    skip = False
+    skipReason = None
+    skipMessage = None
     try:
-        ##> ------ Dheeraj Deshwal : dheeraj9811 Email:dheeraj20194@iiitd.ac.in/dheerajdeshwal9811@gmail.com - Feature ------
-        jobDescription = "Unknown"
-        ##<
-        experience_required = "Unknown"
         found_masters = 0
         jobDescription = find_by_class(driver, "jobs-box__html-content").text
         jobDescriptionLow = jobDescription.lower()
-        skip = False
-        skipReason = None
-        skipMessage = None
         for word in bad_words:
             if word.lower() in jobDescriptionLow:
                 skipMessage = f'\n{jobDescription}\n\nContains bad word "{word}". Skipping this job!\n'
@@ -418,8 +420,7 @@ def get_job_description(
             experience_required = "Error in extraction"
             print_lg("Unable to extract years of experience required!")
             # print_lg(e)
-    finally:
-        return jobDescription, experience_required, skip, skipReason, skipMessage
+    return jobDescription, experience_required, skip, skipReason, skipMessage
         
 
 


### PR DESCRIPTION
## What
`get_job_description()` had `return ...` inside a `finally:` block.

## Why it matters
- A `return` in `finally` **silently swallows any exception** raised in the `try` body, and Python 3.12+ emits a `SyntaxWarning` for it.
- It also masked a latent bug: `skip`, `skipReason`, and `skipMessage` were only assigned *after* `find_by_class()`. If the job-description element wasn't found, those names were never bound, so the `finally` return raised `UnboundLocalError` instead of returning gracefully.

## Fix
- Initialise all five return values **before** the `try`.
- Move the `return` **out of** `finally` to the end of the function.

## Verified
- Repo compiles with **no SyntaxWarning**.
- Early-failure path now returns `('Unknown','Unknown',False,None,None)` instead of crashing.
- Success path and the 'description found but experience extraction failed' path are unchanged.

The attestation marker on `jobDescription = "Unknown"` is preserved.