### PR TITLE
Simplify the control panel: AI master switch, model list, advanced sections, layout fixes

### DIFF
--- a/config_schema.py
+++ b/config_schema.py
@@ -24,11 +24,18 @@ Each field is a dict:
       "type":          one of text, password, textarea, number, bool, select, list,
       "help":          plain-language explanation (from the config comments),
       "options":       list of allowed values (select fields only),
+      "advanced":      (optional) True -> shown under a collapsible "Advanced
+                       options" section so the default view stays simple,
+      "ai":            (optional) True -> the field only matters when "Use AI" is
+                       on, so the UI disables it while AI is turned off,
+      "models_by_provider": (optional) suggestions for the model field, keyed by
+                       AI provider; the UI shows them as a dropdown but still
+                       accepts any typed-in model name,
     }
 
 Field types:
     text      - single line of text
-    password  - single line, masked in the browser
+    password  - single line, masked in the browser (with a show/hide toggle)
     textarea  - multi-line text
     number    - stored as a number (int/float), not quoted
     bool      - True / False checkbox
@@ -37,7 +44,25 @@ Field types:
 '''
 
 
-def _f(section, config_module, key, label, ftype, help, options=None):
+# Suggested model names per provider. These are only suggestions shown in a
+# dropdown; any model name can still be typed in, since providers add and rename
+# models often. Local models (Ollama / LM Studio) use the "openai" provider.
+AI_MODELS = {
+    "openai": [
+        "gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-mini", "o4-mini",
+        "gpt-5", "gpt-5-mini",
+        "llama-3.2-3b-instruct", "qwen2.5:latest",
+    ],
+    "deepseek": ["deepseek-chat", "deepseek-reasoner"],
+    "gemini": [
+        "gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.0-flash",
+        "gemini-1.5-flash", "gemini-1.5-pro",
+    ],
+}
+
+
+def _f(section, config_module, key, label, ftype, help,
+       options=None, advanced=False, ai=False, models_by_provider=None):
     field = {
         "section": section,
         "config_module": config_module,
@@ -48,11 +73,19 @@ def _f(section, config_module, key, label, ftype, help, options=None):
     }
     if options is not None:
         field["options"] = options
+    if advanced:
+        field["advanced"] = True
+    if ai:
+        field["ai"] = True
+    if models_by_provider is not None:
+        field["models_by_provider"] = models_by_provider
     return field
 
 
 # ---------------------------------------------------------------------------
 # The schema, grouped into tabs. Each tab is {"section", "fields": [...]}.
+# Within a tab, fields marked advanced=True are tucked into a collapsible
+# "Advanced options" section by the UI so the everyday view stays simple.
 # ---------------------------------------------------------------------------
 SCHEMA = [
     {
@@ -63,26 +96,35 @@ SCHEMA = [
             _f("Account", "secrets", "password", "LinkedIn password", "password",
                "Your LinkedIn password. Stored only on this computer in user_config.json (never uploaded anywhere). Optional - leave blank to log in manually."),
             _f("Account", "secrets", "use_AI", "Use AI", "bool",
-               "Turn on AI help for tailoring answers, resumes and cover letters. Only turn this on if you have a local AI model running or a paid API key (see the fields below). Off by default."),
+               "Master switch for AI help (tailoring answers, resumes and cover letters). Turn this on only if you have a paid API key or a local AI model running. While it's off, all the AI settings below are disabled."),
             _f("Account", "secrets", "ai_provider", "AI provider", "select",
-               "Which AI service to use. Pick 'openai' for OpenAI or any OpenAI-compatible service (like Ollama or LM Studio), 'deepseek' for DeepSeek, or 'gemini' for Google Gemini.",
-               options=["openai", "deepseek", "gemini"]),
-            _f("Account", "secrets", "llm_api_url", "AI API URL", "text",
-               "The address of your AI service. Examples: https://api.openai.com/v1/ , http://localhost:1234/v1/ , https://api.deepseek.com . Keep the trailing slash. You may not need this for Gemini."),
+               "Which AI service to use. Pick 'openai' for OpenAI or any OpenAI-compatible service (including local ones like Ollama or LM Studio), 'deepseek' for DeepSeek, or 'gemini' for Google Gemini.",
+               options=["openai", "deepseek", "gemini"], ai=True),
+            _f("Account", "secrets", "llm_model", "AI model", "text",
+               "The model to use. Pick a suggestion from the list or type any model name your provider supports.",
+               ai=True, models_by_provider=AI_MODELS),
             _f("Account", "secrets", "llm_api_key", "AI API key", "password",
-               "Your AI service API key. Use 'not-needed' for local models like Ollama. Leaving it wrong will cause errors when AI is on."),
-            _f("Account", "secrets", "llm_model", "AI model name", "text",
-               "The model to use. Examples: gpt-4o, gpt-5-mini, llama-3.2-3b-instruct, gemini-2.5-flash, deepseek-llm:latest."),
-            _f("Account", "secrets", "llm_spec", "AI API type", "text",
-               "How the tool should talk to the model. Most services work with 'openai'. Options include openai, openai-like, deepseek, gemini."),
+               "Your AI service API key. Use 'not-needed' for local models like Ollama. A wrong key causes errors while AI is on.",
+               ai=True),
+            # --- advanced AI plumbing ---
+            _f("Account", "secrets", "llm_api_url", "AI API URL", "text",
+               "The address of your AI service. Examples: https://api.openai.com/v1/ , http://localhost:1234/v1/ , https://api.deepseek.com . Keep the trailing slash. You may not need this for Gemini.",
+               ai=True, advanced=True),
+            _f("Account", "secrets", "llm_spec", "AI API type", "select",
+               "How the tool talks to the model. Most services work with 'openai'. Only change this if your provider needs a different protocol.",
+               options=["openai", "openai-like", "deepseek", "gemini"], ai=True, advanced=True),
             _f("Account", "secrets", "stream_output", "Stream AI output", "bool",
-               "Show the AI's answer as it is being written. Off is a little faster; on feels more responsive."),
+               "Show the AI's answer as it is being written. Off is a little faster; on feels more responsive.",
+               ai=True, advanced=True),
+            _f("Account", "settings", "showAiErrorAlerts", "Show AI error alerts", "bool",
+               "Pop up an alert if there's a problem connecting to the AI service.",
+               ai=True, advanced=True),
         ],
     },
     {
         "section": "Profile",
         "fields": [
-            # --- personals.py ---
+            # --- everyday details ---
             _f("Profile", "personals", "first_name", "First name", "text",
                "Your legal first name."),
             _f("Profile", "personals", "middle_name", "Middle name", "text",
@@ -93,36 +135,11 @@ SCHEMA = [
                "A valid phone number. Applications often require this."),
             _f("Profile", "personals", "current_city", "Current city", "text",
                "The city you live in. If left blank, the tool fills in the job's location instead."),
-            _f("Profile", "personals", "street", "Street address", "text",
-               "Your street address. Some applications require it."),
-            _f("Profile", "personals", "state", "State / region", "text",
-               "Your state or region."),
-            _f("Profile", "personals", "zipcode", "ZIP / postal code", "text",
-               "Your ZIP or postal code."),
-            _f("Profile", "personals", "country", "Country", "text",
-               "The country you live in."),
-            _f("Profile", "personals", "ethnicity", "Ethnicity / race", "select",
-               "Used for optional US equal-opportunity questions. Choose 'Decline' to prefer not to answer. A blank leaves the question unanswered, but some companies make it required.",
-               options=["", "Decline", "Hispanic/Latino", "American Indian or Alaska Native", "Asian", "Black or African American", "Native Hawaiian or Other Pacific Islander", "White", "Other"]),
-            _f("Profile", "personals", "gender", "Gender", "select",
-               "Used for optional equal-opportunity questions. Choose 'Decline' to prefer not to answer, or leave blank to skip (some companies require it).",
-               options=["", "Male", "Female", "Other", "Decline"]),
-            _f("Profile", "personals", "disability_status", "Disability status", "select",
-               "Do you have, or have a record of, a disability? Choose 'Decline' to prefer not to answer.",
-               options=["Yes", "No", "Decline"]),
-            _f("Profile", "personals", "veteran_status", "Veteran status", "select",
-               "Your veteran status. Choose 'Decline' to prefer not to answer.",
-               options=["Yes", "No", "Decline"]),
-            # --- questions.py ---
             _f("Profile", "questions", "years_of_experience", "Years of experience", "text",
                "What to answer for 'how many years of experience do you have' questions. A number in text, e.g. 0, 1, 3, 5."),
             _f("Profile", "questions", "require_visa", "Need visa sponsorship?", "select",
                "Do you need visa sponsorship now or in the future?",
                options=["Yes", "No"]),
-            _f("Profile", "questions", "website", "Portfolio website", "text",
-               "Link to your portfolio or personal website. Leave blank to skip this question."),
-            _f("Profile", "questions", "linkedIn", "LinkedIn profile URL", "text",
-               "The link to your LinkedIn profile, e.g. https://www.linkedin.com/in/yourname ."),
             _f("Profile", "questions", "us_citizenship", "Citizenship status", "select",
                "Your work-authorization / citizenship status for US applications.",
                options=["U.S. Citizen/Permanent Resident", "Non-citizen allowed to work for any employer", "Non-citizen allowed to work for current employer", "Non-citizen seeking work authorization", "Canadian Citizen/Permanent Resident", "Other"]),
@@ -132,18 +149,43 @@ SCHEMA = [
                "Your current salary or CTC as a plain number, e.g. 80000."),
             _f("Profile", "questions", "notice_period", "Notice period (days)", "number",
                "Your notice period in days, e.g. 0, 15, 30. The tool converts to weeks or months if a form asks that way."),
-            _f("Profile", "questions", "linkedin_headline", "LinkedIn headline", "text",
-               "A short professional headline, e.g. 'Full Stack Developer, MSc Computer Science, 4+ years experience'. Leave blank to skip."),
-            _f("Profile", "questions", "linkedin_summary", "LinkedIn summary", "textarea",
-               "A few sentences about your background and skills. Used to answer 'tell us about yourself' style questions. Leave blank to skip."),
-            _f("Profile", "questions", "cover_letter", "Cover letter", "textarea",
-               "A default cover letter to submit when one is requested. Leave blank to skip."),
-            _f("Profile", "questions", "recent_employer", "Most recent employer", "text",
-               "The name of your most recent employer."),
-            _f("Profile", "questions", "confidence_level", "Confidence level (1-10)", "text",
-               "For 'on a scale of 1-10, how much experience...' questions. Any number from 1 to 10."),
+            _f("Profile", "questions", "linkedIn", "LinkedIn profile URL", "text",
+               "The link to your LinkedIn profile, e.g. https://www.linkedin.com/in/yourname ."),
+            _f("Profile", "questions", "website", "Portfolio website", "text",
+               "Link to your portfolio or personal website. Leave blank to skip this question."),
             _f("Profile", "questions", "default_resume_path", "Default resume path", "text",
                "Path to the resume file to upload, relative to the project folder, e.g. all resumes/default/resume.pdf . If the file is missing, the tool keeps your last resume on LinkedIn."),
+            # --- advanced / less-common details ---
+            _f("Profile", "personals", "street", "Street address", "text",
+               "Your street address. Some applications require it.", advanced=True),
+            _f("Profile", "personals", "state", "State / region", "text",
+               "Your state or region.", advanced=True),
+            _f("Profile", "personals", "zipcode", "ZIP / postal code", "text",
+               "Your ZIP or postal code.", advanced=True),
+            _f("Profile", "personals", "country", "Country", "text",
+               "The country you live in.", advanced=True),
+            _f("Profile", "personals", "ethnicity", "Ethnicity / race", "select",
+               "Used for optional US equal-opportunity questions. Choose 'Decline' to prefer not to answer. A blank leaves the question unanswered, but some companies make it required.",
+               options=["", "Decline", "Hispanic/Latino", "American Indian or Alaska Native", "Asian", "Black or African American", "Native Hawaiian or Other Pacific Islander", "White", "Other"], advanced=True),
+            _f("Profile", "personals", "gender", "Gender", "select",
+               "Used for optional equal-opportunity questions. Choose 'Decline' to prefer not to answer, or leave blank to skip (some companies require it).",
+               options=["", "Male", "Female", "Other", "Decline"], advanced=True),
+            _f("Profile", "personals", "disability_status", "Disability status", "select",
+               "Do you have, or have a record of, a disability? Choose 'Decline' to prefer not to answer.",
+               options=["Yes", "No", "Decline"], advanced=True),
+            _f("Profile", "personals", "veteran_status", "Veteran status", "select",
+               "Your veteran status. Choose 'Decline' to prefer not to answer.",
+               options=["Yes", "No", "Decline"], advanced=True),
+            _f("Profile", "questions", "linkedin_headline", "LinkedIn headline", "text",
+               "A short professional headline, e.g. 'Full Stack Developer, MSc Computer Science, 4+ years experience'. Leave blank to skip.", advanced=True),
+            _f("Profile", "questions", "linkedin_summary", "LinkedIn summary", "textarea",
+               "A few sentences about your background and skills. Used to answer 'tell us about yourself' style questions. Leave blank to skip.", advanced=True),
+            _f("Profile", "questions", "cover_letter", "Cover letter", "textarea",
+               "A default cover letter to submit when one is requested. Leave blank to skip.", advanced=True),
+            _f("Profile", "questions", "recent_employer", "Most recent employer", "text",
+               "The name of your most recent employer.", advanced=True),
+            _f("Profile", "questions", "confidence_level", "Confidence level (1-10)", "text",
+               "For 'on a scale of 1-10, how much experience...' questions. Any number from 1 to 10.", advanced=True),
         ],
     },
     {
@@ -153,19 +195,9 @@ SCHEMA = [
                "Job titles to search for, separated by commas, e.g. Software Engineer, Python Developer, Full Stack Developer."),
             _f("Search", "search", "search_location", "Search location", "text",
                "Where to look for jobs. Examples: United States, India, 'Chicago, Illinois, United States'. Leave blank to not set a location."),
-            _f("Search", "search", "switch_number", "Applications before switching term", "number",
-               "How many applications to submit for one search term before moving on to the next. A number greater than 0."),
-            _f("Search", "search", "randomize_search_order", "Randomize search order", "bool",
-               "Shuffle the order your search terms are used."),
-            _f("Search", "search", "sort_by", "Sort results by", "select",
-               "How LinkedIn should sort results. Leave blank to not change it.",
-               options=["", "Most recent", "Most relevant"]),
             _f("Search", "search", "date_posted", "Date posted", "select",
                "Only include jobs posted within this window. Leave blank to not filter by date.",
                options=["", "Any time", "Past month", "Past week", "Past 24 hours"]),
-            _f("Search", "search", "salary", "Minimum salary", "select",
-               "Only include jobs at or above this salary. Leave blank to not filter by salary.",
-               options=["", "$40,000+", "$60,000+", "$80,000+", "$100,000+", "$120,000+", "$140,000+", "$160,000+", "$180,000+", "$200,000+"]),
             _f("Search", "search", "easy_apply_only", "Easy Apply only", "bool",
                "Only apply to jobs that use LinkedIn's Easy Apply. Recommended on."),
             _f("Search", "search", "experience_level", "Experience level", "list",
@@ -174,20 +206,31 @@ SCHEMA = [
                "Filter by job type, comma-separated. Valid values: Full-time, Part-time, Contract, Temporary, Volunteer, Internship, Other. Leave blank for all."),
             _f("Search", "search", "on_site", "On-site / Remote", "list",
                "Filter by work setting, comma-separated. Valid values: On-site, Remote, Hybrid. Leave blank for all."),
-            _f("Search", "search", "companies", "Only these companies", "list",
-               "Only apply at these companies, comma-separated. Names must match LinkedIn exactly (including capitals). Leave blank for all companies."),
             _f("Search", "search", "current_experience", "Your years of experience", "number",
                "Your actual years of experience. Jobs asking for more than this are skipped. Set to -1 to ignore required experience and apply to everything."),
+            # --- advanced search options ---
+            _f("Search", "search", "switch_number", "Applications before switching term", "number",
+               "How many applications to submit for one search term before moving on to the next. A number greater than 0.", advanced=True),
+            _f("Search", "search", "randomize_search_order", "Randomize search order", "bool",
+               "Shuffle the order your search terms are used.", advanced=True),
+            _f("Search", "search", "sort_by", "Sort results by", "select",
+               "How LinkedIn should sort results. Leave blank to not change it.",
+               options=["", "Most recent", "Most relevant"], advanced=True),
+            _f("Search", "search", "salary", "Minimum salary", "select",
+               "Only include jobs at or above this salary. Leave blank to not filter by salary.",
+               options=["", "$40,000+", "$60,000+", "$80,000+", "$100,000+", "$120,000+", "$140,000+", "$160,000+", "$180,000+", "$200,000+"], advanced=True),
+            _f("Search", "search", "companies", "Only these companies", "list",
+               "Only apply at these companies, comma-separated. Names must match LinkedIn exactly (including capitals). Leave blank for all companies.", advanced=True),
             _f("Search", "search", "did_masters", "I have a master's degree", "bool",
-               "If on, jobs mentioning 'master' are still considered when their required experience is within about 2 years of yours."),
+               "If on, jobs mentioning 'master' are still considered when their required experience is within about 2 years of yours.", advanced=True),
             _f("Search", "search", "security_clearance", "I have a security clearance", "bool",
-               "Whether you hold an active security clearance."),
+               "Whether you hold an active security clearance.", advanced=True),
             _f("Search", "search", "under_10_applicants", "Under 10 applicants only", "bool",
-               "Only apply to jobs with fewer than 10 applicants so far."),
+               "Only apply to jobs with fewer than 10 applicants so far.", advanced=True),
             _f("Search", "search", "in_your_network", "In your network only", "bool",
-               "Only apply to jobs at companies where you have a connection."),
+               "Only apply to jobs at companies where you have a connection.", advanced=True),
             _f("Search", "search", "fair_chance_employer", "Fair-chance employers only", "bool",
-               "Only apply to employers who identify as fair-chance employers."),
+               "Only apply to employers who identify as fair-chance employers.", advanced=True),
         ],
     },
     {
@@ -204,30 +247,27 @@ SCHEMA = [
     {
         "section": "Run settings",
         "fields": [
-            # --- settings.py ---
-            _f("Run settings", "settings", "auto_manage_driver", "Manage Chrome driver automatically", "bool",
-               "Let the tool download and match the right Chrome driver for you. Recommended on so you don't have to install it yourself."),
             _f("Run settings", "settings", "run_in_background", "Run in background", "bool",
                "Hide the Chrome window while it works. Note: turning this on disables the 'pause before submit' and 'pause on hard questions' safety pauses."),
-            _f("Run settings", "settings", "safe_mode", "Safe mode", "bool",
-               "Open Chrome in a clean guest profile. Turn on if Chrome is slow to start or you have several browser profiles."),
-            _f("Run settings", "settings", "click_gap", "Pause between clicks (seconds)", "number",
-               "Roughly how many seconds to wait between actions. A whole number, e.g. 0, 1, 2."),
-            _f("Run settings", "settings", "keep_screen_awake", "Keep screen awake", "bool",
-               "Stop your computer from sleeping while the tool runs. Turn off if you'd rather manage sleep in your system settings."),
-            _f("Run settings", "settings", "close_tabs", "Close external application tabs", "bool",
-               "Close tabs opened for external (non-Easy-Apply) applications. If off, remember to close all tabs before closing the browser."),
-            _f("Run settings", "settings", "follow_companies", "Follow companies after applying", "bool",
-               "Automatically follow a company on LinkedIn after applying to it."),
-            _f("Run settings", "settings", "showAiErrorAlerts", "Show AI error alerts", "bool",
-               "Pop up an alert if there's a problem connecting to the AI service."),
-            # --- questions.py ---
             _f("Run settings", "questions", "pause_before_submit", "Pause before submitting", "bool",
                "Pause on the final screen of each application so you can review it before it's sent. Recommended on. Ignored when 'Run in background' is on."),
             _f("Run settings", "questions", "pause_at_failed_question", "Pause on hard questions", "bool",
                "Pause and wait for you when the tool can't confidently answer a question. If off, it answers randomly. Ignored when 'Run in background' is on."),
+            # --- advanced run options ---
+            _f("Run settings", "settings", "auto_manage_driver", "Manage Chrome driver automatically", "bool",
+               "Let the tool download and match the right Chrome driver for you. Recommended on so you don't have to install it yourself.", advanced=True),
+            _f("Run settings", "settings", "safe_mode", "Safe mode", "bool",
+               "Open Chrome in a clean guest profile. Turn on if Chrome is slow to start or you have several browser profiles.", advanced=True),
+            _f("Run settings", "settings", "click_gap", "Pause between clicks (seconds)", "number",
+               "Roughly how many seconds to wait between actions. A whole number, e.g. 0, 1, 2.", advanced=True),
+            _f("Run settings", "settings", "keep_screen_awake", "Keep screen awake", "bool",
+               "Stop your computer from sleeping while the tool runs. Turn off if you'd rather manage sleep in your system settings.", advanced=True),
+            _f("Run settings", "settings", "close_tabs", "Close external application tabs", "bool",
+               "Close tabs opened for external (non-Easy-Apply) applications. If off, remember to close all tabs before closing the browser.", advanced=True),
+            _f("Run settings", "settings", "follow_companies", "Follow companies after applying", "bool",
+               "Automatically follow a company on LinkedIn after applying to it.", advanced=True),
             _f("Run settings", "questions", "overwrite_previous_answers", "Overwrite saved answers", "bool",
-               "Replace answers you've previously entered on LinkedIn with the ones configured here."),
+               "Replace answers you've previously entered on LinkedIn with the ones configured here.", advanced=True),
         ],
     },
 ]

--- a/templates/control_panel.html
+++ b/templates/control_panel.html
@@ -30,6 +30,7 @@
             --shadow: 0 1px 3px rgba(16,24,40,.08), 0 1px 2px rgba(16,24,40,.06);
         }
         * { box-sizing: border-box; }
+        html { -webkit-text-size-adjust: 100%; }
         body {
             margin: 0;
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -44,7 +45,7 @@
         }
         header h1 { margin: 0 0 4px; font-size: 20px; }
         header p { margin: 0; color: var(--muted); font-size: 14px; }
-        .wrap { max-width: 900px; margin: 0 auto; padding: 0 16px; }
+        .wrap { width: 100%; max-width: 900px; margin: 0 auto; padding: 0 16px; }
         nav {
             display: flex;
             flex-wrap: wrap;
@@ -64,10 +65,13 @@
             font-weight: 600;
             color: var(--muted);
             cursor: pointer;
+            white-space: nowrap;
         }
         nav button:hover { color: var(--ink); }
         nav button.active { color: var(--brand); border-bottom-color: var(--brand); }
-        main { padding: 24px 0 80px; }
+        /* Top margin so the first setting isn't flush against the tab bar, and a
+           generous bottom gap so the fixed save bar never hides the last field. */
+        main { padding: 28px 0 140px; }
         .panel { display: none; }
         .panel.active { display: block; }
         .field {
@@ -101,8 +105,37 @@
             box-shadow: 0 0 0 3px rgba(37,99,235,.15);
         }
         .checkline { display: flex; align-items: center; gap: 10px; }
-        .checkline input[type=checkbox] { width: 20px; height: 20px; accent-color: var(--brand); }
+        .checkline input[type=checkbox] { width: 20px; height: 20px; flex: none; accent-color: var(--brand); }
         .checkline label { margin: 0; }
+        /* Password field with a show/hide eye button. */
+        .pw-wrap { position: relative; }
+        .pw-wrap input { padding-right: 46px; }
+        .pw-eye {
+            position: absolute; top: 50%; right: 6px; transform: translateY(-50%);
+            background: none; border: none; padding: 6px; margin: 0;
+            display: inline-flex; align-items: center; justify-content: center;
+            color: var(--muted); cursor: pointer; border-radius: 6px;
+        }
+        .pw-eye:hover { color: var(--ink); background: #eef1f6; }
+        .pw-eye svg { display: block; }
+        /* AI fields disabled while "Use AI" is off. */
+        .field.disabled { opacity: .5; }
+        .field.disabled input, .field.disabled select,
+        .field.disabled textarea, .field.disabled .pw-eye { cursor: not-allowed; }
+        /* Collapsible "Advanced options" section per tab. */
+        details.advanced { margin: 4px 0 12px; }
+        details.advanced > summary {
+            cursor: pointer; user-select: none; list-style: none;
+            font-weight: 600; font-size: 14px; color: var(--brand);
+            padding: 11px 14px; background: var(--card);
+            border: 1px solid var(--line); border-radius: 10px;
+            box-shadow: var(--shadow);
+        }
+        details.advanced > summary::-webkit-details-marker { display: none; }
+        details.advanced > summary::before { content: "\25B8\00a0\00a0"; }
+        details.advanced[open] > summary::before { content: "\25BE\00a0\00a0"; }
+        details.advanced > summary:hover { background: #f7f9fc; }
+        details.advanced > .adv-body { padding-top: 12px; }
         .savebar {
             position: fixed;
             bottom: 0; left: 0; right: 0;
@@ -114,7 +147,9 @@
             gap: 14px;
             justify-content: flex-end;
             box-shadow: 0 -1px 3px rgba(16,24,40,.06);
+            z-index: 6;
         }
+        .savebar .inner { width: 100%; max-width: 900px; margin: 0 auto; display: flex; align-items: center; gap: 14px; }
         .savebar .msg { margin-right: auto; font-size: 14px; color: var(--muted); }
         .savebar .msg.ok { color: var(--ok); }
         .savebar .msg.err { color: var(--danger); }
@@ -152,9 +187,9 @@
             box-shadow: var(--shadow);
         }
         .status-line { display: flex; align-items: center; gap: 10px; margin-bottom: 14px; font-weight: 600; }
-        .dot { width: 12px; height: 12px; border-radius: 50%; background: #cbd2dc; }
+        .dot { width: 12px; height: 12px; border-radius: 50%; background: #cbd2dc; flex: none; }
         .dot.on { background: var(--ok); box-shadow: 0 0 0 4px rgba(22,163,74,.15); }
-        .run-actions { display: flex; gap: 10px; margin-bottom: 8px; }
+        .run-actions { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 8px; }
         pre.log {
             background: #0f172a;
             color: #e2e8f0;
@@ -178,8 +213,20 @@
         table.jobs a:hover { text-decoration: underline; }
         .tick { color: var(--ok); font-weight: 700; }
         .muted-small { color: var(--muted); font-size: 13px; }
-        @media (max-width: 560px) {
-            nav button { padding: 10px 10px; font-size: 13px; }
+
+        /* --- Responsive --- */
+        @media (max-width: 640px) {
+            header { padding: 16px 16px; }
+            header h1 { font-size: 18px; }
+            .wrap { padding: 0 12px; }
+            /* Tab bar scrolls sideways instead of wrapping into tall rows. */
+            nav { flex-wrap: nowrap; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+            nav button { padding: 11px 12px; font-size: 13px; }
+            main { padding: 22px 0 168px; }
+            .savebar { padding: 10px 12px; }
+            .savebar .inner { flex-wrap: wrap; gap: 8px; }
+            .savebar .msg { flex-basis: 100%; margin: 0; }
+            .savebar .btn { flex: 1 1 auto; }
         }
     </style>
 </head>
@@ -198,16 +245,23 @@
     </main>
 
     <div class="savebar" id="savebar">
-        <span class="msg" id="saveMsg">Make your changes across the tabs, then click Save.</span>
-        <button class="btn secondary" id="reloadBtn" type="button">Reload</button>
-        <button class="btn" id="saveBtn" type="button">Save</button>
+        <div class="inner">
+            <span class="msg" id="saveMsg">Make your changes across the tabs, then click Save.</span>
+            <button class="btn secondary" id="reloadBtn" type="button">Reload</button>
+            <button class="btn" id="saveBtn" type="button">Save</button>
+        </div>
     </div>
 
     <script>
+        // ---- icons ----
+        var EYE_SVG = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>';
+        var EYE_OFF_SVG = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>';
+
         // ---- state ----
         var SCHEMA = [];
         var CONFIG = {};        // {config_module: {key: value}}
         var BASELINE = {};      // JSON snapshot for change detection
+        var MODEL_FIELDS = [];  // [{datalistId, models}] for provider-aware model lists
         var activeTab = null;
         var logOffset = 0;
         var pollTimer = null;
@@ -227,6 +281,7 @@
         }
 
         function fieldId(field) { return 'f__' + field.config_module + '__' + field.key; }
+        function datalistId(field) { return 'dl__' + field.config_module + '__' + field.key; }
 
         function currentValue(cm, key) {
             if (CONFIG[cm] && Object.prototype.hasOwnProperty.call(CONFIG[cm], key)) {
@@ -235,41 +290,89 @@
             return '';
         }
 
+        function asText(value) {
+            return (value === null || value === undefined) ? '' : String(value);
+        }
+
         // ---- rendering ----
+        function makePasswordControl(id, value) {
+            var wrap = el('div', { class: 'pw-wrap' });
+            var input = el('input', { type: 'password', id: id });
+            input.value = value;
+            var btn = el('button', { type: 'button', class: 'pw-eye', 'aria-label': 'Show password', html: EYE_SVG });
+            btn.addEventListener('click', function () {
+                if (input.disabled) return;
+                if (input.type === 'password') {
+                    input.type = 'text'; btn.innerHTML = EYE_OFF_SVG; btn.setAttribute('aria-label', 'Hide password');
+                } else {
+                    input.type = 'password'; btn.innerHTML = EYE_SVG; btn.setAttribute('aria-label', 'Show password');
+                }
+            });
+            wrap.appendChild(input);
+            wrap.appendChild(btn);
+            return wrap;
+        }
+
+        function makeModelControl(field, value) {
+            var wrap = el('div', {});
+            var input = el('input', { type: 'text', id: fieldId(field), list: datalistId(field), autocomplete: 'off' });
+            input.value = value;
+            var dl = el('datalist', { id: datalistId(field) });
+            wrap.appendChild(input);
+            wrap.appendChild(dl);
+            MODEL_FIELDS.push({ datalistId: datalistId(field), models: field.models_by_provider || {} });
+            return wrap;
+        }
+
         function renderControl(field) {
             var value = currentValue(field.config_module, field.key);
             var id = fieldId(field);
-            var control;
             if (field.type === 'bool') {
-                control = el('input', { type: 'checkbox', id: id });
-                if (value === true) control.checked = true;
-            } else if (field.type === 'textarea') {
-                control = el('textarea', { id: id });
-                control.value = (value === null || value === undefined) ? '' : String(value);
-            } else if (field.type === 'select') {
-                control = el('select', { id: id });
+                var cb = el('input', { type: 'checkbox', id: id });
+                if (value === true) cb.checked = true;
+                return cb;
+            }
+            if (field.type === 'textarea') {
+                var ta = el('textarea', { id: id });
+                ta.value = asText(value);
+                return ta;
+            }
+            if (field.type === 'select') {
+                var sel = el('select', { id: id });
                 (field.options || []).forEach(function (opt) {
                     var o = el('option', { value: opt, text: opt === '' ? '(leave unanswered)' : opt });
                     if (String(value) === String(opt)) o.selected = true;
-                    control.appendChild(o);
+                    sel.appendChild(o);
                 });
-            } else if (field.type === 'list') {
-                control = el('input', { type: 'text', id: id });
-                control.value = Array.isArray(value) ? value.join(', ') : (value || '');
-            } else if (field.type === 'number') {
-                control = el('input', { type: 'number', id: id, step: 'any' });
-                control.value = (value === null || value === undefined) ? '' : String(value);
-            } else {
-                var t = field.type === 'password' ? 'password' : 'text';
-                control = el('input', { type: t, id: id });
-                control.value = (value === null || value === undefined) ? '' : String(value);
+                return sel;
             }
-            return control;
+            if (field.type === 'list') {
+                var li = el('input', { type: 'text', id: id });
+                li.value = Array.isArray(value) ? value.join(', ') : asText(value);
+                return li;
+            }
+            if (field.type === 'number') {
+                var nu = el('input', { type: 'number', id: id, step: 'any' });
+                nu.value = asText(value);
+                return nu;
+            }
+            if (field.type === 'password') {
+                return makePasswordControl(id, asText(value));
+            }
+            if (field.models_by_provider) {
+                return makeModelControl(field, asText(value));
+            }
+            var t = el('input', { type: 'text', id: id });
+            t.value = asText(value);
+            return t;
         }
 
         function renderField(field) {
             var control = renderControl(field);
             var box = el('div', { class: 'field' });
+            box.dataset.cm = field.config_module;
+            box.dataset.key = field.key;
+            if (field.ai) box.dataset.ai = '1';
             if (field.type === 'bool') {
                 var line = el('div', { class: 'checkline' });
                 line.appendChild(control);
@@ -289,6 +392,7 @@
             var panels = document.getElementById('panels');
             tabs.innerHTML = '';
             panels.innerHTML = '';
+            MODEL_FIELDS = [];
 
             SCHEMA.forEach(function (section) {
                 var btn = el('button', { type: 'button', text: section.section });
@@ -298,7 +402,21 @@
 
                 var panel = el('div', { class: 'panel' });
                 panel.dataset.tab = section.section;
-                section.fields.forEach(function (field) { panel.appendChild(renderField(field)); });
+
+                var common = section.fields.filter(function (f) { return !f.advanced; });
+                var advanced = section.fields.filter(function (f) { return f.advanced; });
+
+                common.forEach(function (field) { panel.appendChild(renderField(field)); });
+
+                if (advanced.length) {
+                    var det = el('details', { class: 'advanced' });
+                    det.appendChild(el('summary', { text: 'Advanced options' }));
+                    var body = el('div', { class: 'adv-body' });
+                    advanced.forEach(function (field) { body.appendChild(renderField(field)); });
+                    det.appendChild(body);
+                    panel.appendChild(det);
+                }
+
                 panels.appendChild(panel);
             });
 
@@ -308,6 +426,10 @@
             runBtn.addEventListener('click', function () { showTab('Run'); });
             tabs.appendChild(runBtn);
             panels.appendChild(buildRunPanel());
+
+            wireAi();
+            updateModelLists();
+            applyAiState();
 
             showTab(SCHEMA.length ? SCHEMA[0].section : 'Run');
         }
@@ -323,6 +445,45 @@
             var isRun = (name === 'Run');
             document.getElementById('savebar').style.display = isRun ? 'none' : 'flex';
             if (isRun) { refreshStatus(); refreshLogs(); loadAppliedJobs(); }
+        }
+
+        // ---- AI master switch + model lists ----
+        function useAiEnabled() {
+            var cb = document.getElementById('f__secrets__use_AI');
+            return cb ? cb.checked : false;
+        }
+
+        function applyAiState() {
+            var enabled = useAiEnabled();
+            document.querySelectorAll('.field[data-ai="1"]').forEach(function (box) {
+                box.classList.toggle('disabled', !enabled);
+                box.querySelectorAll('input, select, textarea, button').forEach(function (ctrl) {
+                    ctrl.disabled = !enabled;
+                });
+            });
+        }
+
+        function currentProvider() {
+            var sel = document.getElementById('f__secrets__ai_provider');
+            return sel ? sel.value : 'openai';
+        }
+
+        function updateModelLists() {
+            var prov = currentProvider();
+            MODEL_FIELDS.forEach(function (m) {
+                var dl = document.getElementById(m.datalistId);
+                if (!dl) return;
+                dl.innerHTML = '';
+                var list = (m.models && m.models[prov]) || [];
+                list.forEach(function (name) { dl.appendChild(el('option', { value: name })); });
+            });
+        }
+
+        function wireAi() {
+            var cb = document.getElementById('f__secrets__use_AI');
+            if (cb) cb.addEventListener('change', applyAiState);
+            var prov = document.getElementById('f__secrets__ai_provider');
+            if (prov) prov.addEventListener('change', updateModelLists);
         }
 
         // ---- Run tab ----


### PR DESCRIPTION
Addresses the reported UI issues to make the panel simple enough for a non-technical user.

## Fixes (each maps to a reported issue)
- **Save bar hid the last field** → increased bottom clearance on every tab (140px, more on mobile where the bar can wrap taller).
- **Password show/hide** → password fields (LinkedIn password, AI API key) now have an eye toggle.
- **AI master switch** → `Use AI` now enables/disables *all* AI settings. While it's off, every AI field is greyed out and disabled; turning it on enables them.
- **Models list** → `AI model` is now a dropdown of common models that updates with the selected provider (OpenAI / DeepSeek / Gemini), while still accepting any typed-in model name.
- **AI API type under advanced** → `AI API type` (and the other AI plumbing: API URL, stream output, error alerts) moved into a collapsible **Advanced options** section.
- **Declutter** → every tab now shows only the everyday fields; rarely-changed settings are tucked into a per-tab **Advanced options** disclosure. (I used a per-tab collapsible rather than one global Advanced tab so related settings stay together — happy to switch to a single tab if you prefer.)
- **Margin after the tab list** → added spacing below the sticky tab bar.
- **Responsive** → tab bar scrolls sideways on narrow screens; the save bar, buttons, and run actions reflow on mobile; content is fluid.

## Not changed
- `app.py` — no backend change needed. The model field stays a text field, so the dropdown is purely front-end and existing validation/coercion is untouched.
- Still vanilla HTML/CSS/JS, no external libraries, works offline. Non-breaking: with no `user_config.json` the tool is unchanged.

## Tested (in-process, via Flask test client)
- Schema exposes the new flags; `Use AI` present; AI API type is advanced+AI; model field carries per-provider suggestions.
- HTML serves with the eye toggle, Advanced sections, AI-toggle logic, and model list.
- Config POST round-trip still works; unknown keys still rejected (400).

## Please eyeball
The functional side is verified, but the layout fixes (footer clearance, spacing, responsiveness) are best confirmed visually — pull this branch and refresh the panel in your browser.