### PR TITLE
Fix control panel: port 5000/macOS conflict + footer overlap (CSS specificity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ New here, or not comfortable editing code? Use the built-in control panel. You s
     - **Linux:** `start.sh` (run `./start.sh` in a terminal)
 
     The first run sets things up automatically (it may take a minute). After that it's quick.
-4. Your browser opens the **control panel** at `http://127.0.0.1:5000`. Fill in the tabs - **Account, Profile, Search, Filters, Run settings** - and click **Save**.
+4. Your browser opens the **control panel** automatically (the exact address, e.g. `http://127.0.0.1:5000`, is shown in the launcher window). Fill in the tabs - **Account, Profile, Search, Filters, Run settings** - and click **Save**.
 5. Go to the **Run** tab and click **Start**. A Chrome window opens and begins applying - keep it in the foreground. You can watch progress in the log and click **Stop** any time.
 
 Everything stays on your own computer: your details are saved locally in `user_config.json` (never uploaded), and the control panel is reachable only from this machine. If you prefer the classic setup, the manual steps below still work exactly as before.
@@ -76,7 +76,7 @@ Click on above image to watch the tutorial for installation and configuration or
 5. Open `settings.py` file in `/config` folder to configure settings like keep screen awake, click interval (time to wait between actions), run in background, automatic Chrome-driver management, etc. as per your needs.
 6. (Optional) Don't forget to add you default resume in the location you mentioned in `default_resume_path = "all resumes/default/resume.pdf"` given in `/config/questions.py`. If one is not provided, it will use your previous resume submitted in LinkedIn or (In Development) generate custom resume if OpenAI APT key is provided!
 7. Run `runAiBot.py` and see the magic happen.
-8. To run the Applied Jobs history UI, run `app.py` and open web browser on `http://localhost:5000`.
+8. To run the local control panel (settings, run controls, and Applied Jobs history), run `app.py` - it prints the address to open (e.g. `http://127.0.0.1:5000`, or another port if 5000 is busy).
 8. If you have questions or need help setting it up or to talk in general, join the github server: https://discord.gg/fFp7uUzWCY
 
 [back to index](#-content)

--- a/app.py
+++ b/app.py
@@ -464,6 +464,41 @@ def api_logs():
         return jsonify({"content": "", "next_offset": offset, "error": str(err)})
 
 
+def _resolve_port(preferred: int = 5000) -> int:
+    '''
+    Pick a port to serve on. Honors the PORT environment variable (the launcher
+    scripts set it). Otherwise tries `preferred`, and if that's taken - e.g. port
+    5000 is used by AirPlay Receiver on macOS - asks the OS for any free port so
+    the panel always starts instead of crashing with "address already in use".
+    '''
+    import socket
+    requested = os.environ.get("PORT", "").strip()
+    if requested.isdigit():
+        return int(requested)
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        try:
+            probe.bind(("127.0.0.1", preferred))
+            return preferred
+        except OSError:
+            pass
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
 if __name__ == '__main__':
     # SECURITY: localhost only, debug OFF. This app handles credentials.
-    app.run(host="127.0.0.1", port=5000, debug=False)
+    port = _resolve_port(5000)
+    url = "http://127.0.0.1:%d" % port
+    print(
+        "\n  Control panel ready at:  %s\n"
+        "  Keep this window open while you use the tool; close it to stop.\n" % url,
+        flush=True,
+    )
+    # The launcher scripts set PANEL_OPEN_BROWSER=1 so the browser opens itself,
+    # to the right port, cross-platform. Running `python app.py` by hand won't.
+    if os.environ.get("PANEL_OPEN_BROWSER", "").strip() not in ("", "0", "false", "False"):
+        import threading
+        import webbrowser
+        threading.Timer(1.5, lambda: webbrowser.open(url)).start()
+    app.run(host="127.0.0.1", port=port, debug=False)

--- a/start.bat
+++ b/start.bat
@@ -59,11 +59,12 @@ if not exist ".venv\.deps_installed" (
     echo done> ".venv\.deps_installed"
 )
 
-REM 4) Open the browser shortly after the server starts.
-start "" cmd /c "timeout /t 2 /nobreak >nul & start "" http://127.0.0.1:5000"
+REM 4) Start the control panel. It chooses a free port, prints the address, and
+REM    opens your browser to it.
+set "PANEL_OPEN_BROWSER=1"
 
 echo.
-echo Opening the control panel in your browser at http://127.0.0.1:5000
+echo Starting the control panel and opening it in your browser...
 echo Keep this window open while you use the tool. Close it to stop the server.
 echo.
 

--- a/start.command
+++ b/start.command
@@ -43,11 +43,12 @@ if [ ! -f ".venv/.deps_installed" ]; then
     touch ".venv/.deps_installed"
 fi
 
-# 4) Open the browser shortly after the server starts.
-( sleep 2; open "http://127.0.0.1:5000" >/dev/null 2>&1 ) &
+# 4) Start the control panel. It chooses a free port (port 5000 is used by
+#    AirPlay on macOS), prints the address, and opens your browser to it.
+export PANEL_OPEN_BROWSER=1
 
 echo ""
-echo "Opening the control panel in your browser at http://127.0.0.1:5000"
+echo "Starting the control panel and opening it in your browser..."
 echo "Keep this window open while you use the tool. Close it to stop the server."
 echo ""
 

--- a/start.sh
+++ b/start.sh
@@ -41,14 +41,13 @@ if [ ! -f ".venv/.deps_installed" ]; then
     touch ".venv/.deps_installed"
 fi
 
-# 4) Open the browser shortly after the server starts (if a browser opener exists).
-if command -v xdg-open >/dev/null 2>&1; then
-    ( sleep 2; xdg-open "http://127.0.0.1:5000" >/dev/null 2>&1 ) &
-fi
+# 4) Start the control panel. It chooses a free port, prints the address, and
+#    opens your browser to it.
+export PANEL_OPEN_BROWSER=1
 
 echo ""
-echo "Open the control panel in your browser at http://127.0.0.1:5000"
-echo "Keep this terminal open while you use the tool. Press Ctrl+C to stop the server."
+echo "Starting the control panel and opening it in your browser..."
+echo "The address is printed below. Keep this terminal open; press Ctrl+C to stop."
 echo ""
 
 # 5) Start the local control panel (runs until you press Ctrl+C).

--- a/templates/control_panel.html
+++ b/templates/control_panel.html
@@ -70,8 +70,9 @@
         nav button:hover { color: var(--ink); }
         nav button.active { color: var(--brand); border-bottom-color: var(--brand); }
         /* Top margin so the first setting isn't flush against the tab bar, and a
-           generous bottom gap so the fixed save bar never hides the last field. */
-        main { padding: 28px 0 140px; }
+           generous bottom gap so the fixed save bar never hides the last field.
+           Uses main.wrap (not just main) so it beats the .wrap padding rule. */
+        main.wrap { padding: 28px 16px 150px; }
         .panel { display: none; }
         .panel.active { display: block; }
         .field {
@@ -222,7 +223,7 @@
             /* Tab bar scrolls sideways instead of wrapping into tall rows. */
             nav { flex-wrap: nowrap; overflow-x: auto; -webkit-overflow-scrolling: touch; }
             nav button { padding: 11px 12px; font-size: 13px; }
-            main { padding: 22px 0 168px; }
+            main.wrap { padding: 22px 12px 184px; }
             .savebar { padding: 10px 12px; }
             .savebar .inner { flex-wrap: wrap; gap: 8px; }
             .savebar .msg { flex-basis: 100%; margin: 0; }


### PR DESCRIPTION
Found while actually running the control panel in a browser after the last merge. Two real issues that the earlier static checks couldn't catch.

## 1. Footer still overlapped the last field (and the tab-bar gap was too small)
The previous PR set vertical padding on `main`, but `<main>` also has `class="wrap"`, and the `.wrap { padding: 0 16px }` rule **wins on specificity** — so the padding never applied. That's why the save bar kept hiding the last setting and the space under the tabs looked tight (this bug actually predates the last PR; my larger value just got overridden too).
**Fix:** scope the padding to `main.wrap` (desktop + mobile) so it takes effect.
**Verified:** headless-Chrome check, scrolled to the bottom of a tab — last field bottom now sits ~100px above the save bar (`overlaps: false`), confirmed by screenshot.

## 2. The app wouldn't start on macOS (port 5000 = AirPlay)
Port 5000 is held by macOS AirPlay Receiver (ControlCenter), so `app.py` failed to bind with 'address already in use' on any Mac.
**Fix:** `app.py` now honors a `PORT` env var, and otherwise auto-picks a free port when 5000 is busy; it prints the real address and, when launched via the scripts, opens the browser itself (cross-platform via Python `webbrowser`). The launchers were simplified — no hardcoded port, no OS-specific browser command; they just set `PANEL_OPEN_BROWSER=1` and run the app.
**Verified:** ran `python app.py` with 5000 occupied → it fell back to port 54752, printed the URL, and served `/` and `/api/schema` (HTTP 200) on that port.

## Also verified working (headless browser, this run)
- AI master switch: with 'Use AI' off, all AI fields are disabled/greyed; toggling it on enables them.
- Model list is provider-aware (OpenAI vs Gemini suggestions) and still free-text.
- Password eye toggles the field between masked and visible.
- 'Advanced options' (incl. AI API type) collapses per tab; save bar hides on the Run tab.
- Mobile width: fields stack, save bar reflows.

Still no external libraries; localhost-only; non-breaking.