### PR TITLE
Search: target Customer Success roles (CA + Remote)

### DIFF
--- a/config/search.py
+++ b/config/search.py
@@ -19,10 +19,10 @@ version:    26.01.20.5.08
 
 # These Sentences are Searched in LinkedIn
 # Enter your search terms inside '[ ]' with quotes ' "searching title" ' for each search followed by comma ', ' Eg: ["Software Engineer", "Software Developer", "Selenium Developer"]
-search_terms = ["Software Engineer", "Software Developer", "Python Developer", "Selenium Developer", "React Developer", "Java Developer", "Front End Developer", "Full Stack Developer", "Web Developer", "Nodejs Developer"]
+search_terms = ["Customer Success Manager", "Customer Success", "Customer Success Specialist", "Customer Success Director", "Customer Success Associate"]
 
 # Search location, this will be filled in "City, state, or zip code" search box. If left empty as "", tool will not fill it.
-search_location = "United States"               # Some valid examples: "", "United States", "India", "Chicago, Illinois, United States", "90001, Los Angeles, California, United States", "Bengaluru, Karnataka, India", etc.
+search_location = ""               # Leaving empty so the tool can use the `location` list (California and Remote) instead.
 
 # After how many number of applications in current search should the bot switch to next search? 
 switch_number = 30                 # Only numbers greater than 0... Don't put in quotes
@@ -56,11 +56,11 @@ easy_apply_only = True             # True or False, Note: True or False are case
 
 experience_level = []              # (multiple select) "Internship", "Entry level", "Associate", "Mid-Senior level", "Director", "Executive"
 job_type = []                      # (multiple select) "Full-time", "Part-time", "Contract", "Temporary", "Volunteer", "Internship", "Other"
-on_site = []                       # (multiple select) "On-site", "Remote", "Hybrid"
+on_site = ["Remote"]                       # (multiple select) "On-site", "Remote", "Hybrid"  -- set to include remote roles
 
 companies = []                     # (dynamic multiple select) make sure the name you type in list exactly matches with the company name you're looking for, including capitals. 
                                    # Eg: "7-eleven", "Google","X, the moonshot factory","YouTube","CapitalG","Adometry (acquired by Google)","Meta","Apple","Byte Dance","Netflix", "Snowflake","Mineral.ai","Microsoft","JP Morgan","Barclays","Visa","American Express", "Snap Inc", "JPMorgan Chase & Co.", "Tata Consultancy Services", "Recruiting from Scratch", "Epic", and so on...
-location = []                      # (dynamic multiple select)
+location = ["California, United States"]                      # (dynamic multiple select)  -- set to search California locations
 industry = []                      # (dynamic multiple select)
 job_function = []                  # (dynamic multiple select)
 job_titles = []                    # (dynamic multiple select)


### PR DESCRIPTION
Why:
Narrow LinkedIn search defaults to focus on Customer Success Manager roles in California or Remote so the automation applies only to relevant CSM opportunities.

What:
- Updates config/search.py to set search_terms to Customer Success titles.
- Clears search_location so the dynamic location list is used.
- Sets location to ["California, United States"] and on_site to ["Remote"].
- Preserves easy_apply_only behavior.

Notes:
This change only adjusts default search preferences (non-breaking). No production logic or tests were modified. If pushing the branch to the repository is blocked by permissions, the PR creation flow will fork/push as needed.