### PR TITLE
fix: import only the configured AI provider module (fixes #106)

### DIFF
--- a/runAiBot.py
+++ b/runAiBot.py
@@ -39,9 +39,21 @@ from modules.open_chrome import *
 from modules.helpers import *
 from modules.clickers_and_finders import *
 from modules.validator import validate_config
-from modules.ai.openaiConnections import ai_create_openai_client, ai_extract_skills, ai_answer_question, ai_close_openai_client
-from modules.ai.deepseekConnections import deepseek_create_client, deepseek_extract_skills, deepseek_answer_question
-from modules.ai.geminiConnections import gemini_create_client, gemini_extract_skills, gemini_answer_question
+##> ------ Syed Talha Ahmed Gardazi : stag7824 - Bug fix ------
+# Import only the AI provider that is configured. Importing every provider
+# unconditionally made an unused provider's optional dependency mandatory, so
+# a "deepseek" or "openai" user without `google-generativeai` installed
+# crashed on startup with `ModuleNotFoundError: No module named 'google'`.
+if use_AI:
+    selected_ai_provider = ai_provider.lower()
+    # DeepSeek reuses the OpenAI client helpers, so it needs this module too.
+    if selected_ai_provider in ("openai", "deepseek"):
+        from modules.ai.openaiConnections import ai_create_openai_client, ai_extract_skills, ai_answer_question, ai_close_openai_client
+    if selected_ai_provider == "deepseek":
+        from modules.ai.deepseekConnections import deepseek_create_client, deepseek_extract_skills, deepseek_answer_question
+    if selected_ai_provider == "gemini":
+        from modules.ai.geminiConnections import gemini_create_client, gemini_extract_skills, gemini_answer_question
+##<
 
 from typing import Literal
 


### PR DESCRIPTION
## Problem

`runAiBot.py` imports **all three** AI provider modules at startup, regardless of which one `ai_provider` actually selects:

```python
from modules.ai.openaiConnections import ...
from modules.ai.deepseekConnections import ...
from modules.ai.geminiConnections import ...
```

`modules/ai/geminiConnections.py` imports `google.generativeai` at module level (line 1). So anyone running the OpenAI or DeepSeek provider still pays for Gemini's dependency, and crashes before the bot starts if it isn't installed:

```
ModuleNotFoundError: No module named 'google'
```

This is [#106](https://github.com/GodsScion/Auto_job_applier_linkedIn/issues/106). It also means every user has to install `google-generativeai` — which pulls in ~24 transitive packages (`grpcio`, `protobuf`, `cryptography`, `google-api-python-client`, …) — even when they never touch Gemini.

## Reproduction

In a venv with `openai` and `pyautogui` installed but **not** `google-generativeai`:

```
$ python -c "import modules.ai.openaiConnections"      # ok
$ python -c "import modules.ai.deepseekConnections"    # ok
$ python -c "import modules.ai.geminiConnections"
ModuleNotFoundError: No module named 'google'
```

Since `runAiBot.py` imports the third one unconditionally, that traceback is what an OpenAI/DeepSeek user sees on startup.

## Fix

Gate each provider import on the configured `ai_provider`. The runtime already dispatches on `ai_provider` at every call site (all of them behind `if use_AI and aiClient`), so no call sites change and no names are referenced on a path that didn't already check the provider.

One subtlety worth calling out: **DeepSeek reuses `ai_close_openai_client`** from `openaiConnections` for teardown, so that module is imported for DeepSeek too. Gating it on `openai` alone would break DeepSeek shutdown.

This also matches the existing style in the file — line 50 already has a config-gated import for the resume generator.

## Verification

Same venv, no `google-generativeai` installed:

| `use_AI` | `ai_provider` | Result |
|---|---|---|
| `True` | `openai` | ✅ imports (previously crashed) |
| `True` | `deepseek` | ✅ imports, incl. `ai_close_openai_client` (previously crashed) |
| `True` | `OpenAI` | ✅ imports (case-tolerant) |
| `True` | `gemini` | ❌ `ModuleNotFoundError` — **correct**: only the user who actually selected Gemini needs it |
| `False` | any | ✅ imports nothing at all |

With `google.generativeai` present, `gemini` binds `gemini_create_client` / `gemini_extract_skills` / `gemini_answer_question` as before.

Fixes #106
