### PR TITLE
fix: detect temperature support by model family, not a fixed allow-list

### DIFF
--- a/modules/ai/openaiConnections.py
+++ b/modules/ai/openaiConnections.py
@@ -143,7 +143,24 @@ def model_supports_temperature(model_name: str) -> bool:
     Returns:
         bool: True if the model supports temperature adjustments, otherwise False.
     """
-    return model_name in ["gpt-3.5-turbo", "gpt-4", "gpt-4-turbo", "gpt-4o", "gpt-4o-mini"]
+    ##> ------ Syed Talha Ahmed Gardazi : stag7824 - Bug fix ------
+    # Only OpenAI's reasoning models reject `temperature`; everything else accepts it.
+    # This used to be an allow-list of five OpenAI models, which silently dropped the
+    # configured temperature for every other model - including the local
+    # OpenAI-compatible ones suggested in config/secrets.py (LM Studio, Ollama), and
+    # newer OpenAI models such as gpt-4.1. Deny-listing the reasoning families keeps
+    # o1/o3/o4/gpt-5 working while honouring temperature everywhere else.
+    model = model_name.lower().strip()
+    # Strip an OpenRouter/LiteLLM style "provider/" prefix, e.g. "openai/o3-mini".
+    model = model.rsplit("/", 1)[-1]
+    reasoning_model_prefixes = ("o1", "o3", "o4", "gpt-5")
+    for prefix in reasoning_model_prefixes:
+        # Match the family exactly or a variant of it ("o3", "o3-mini", "o3-mini-2025-01-31"),
+        # without catching unrelated names that merely start with the same letters.
+        if model == prefix or model.startswith(prefix + "-"):
+            return False
+    return True
+    ##<
 
 # Function to get chat completion from OpenAI API
 def ai_completion(client: OpenAI, messages: list[dict], response_format: dict = None, temperature: float = 0, stream: bool = stream_output) -> dict | ValueError:


### PR DESCRIPTION
## Problem

`model_supports_temperature()` in `modules/ai/openaiConnections.py` is an allow-list of five OpenAI model names:

```python
return model_name in ["gpt-3.5-turbo", "gpt-4", "gpt-4-turbo", "gpt-4o", "gpt-4o-mini"]
```

`ai_completion()` only sends `temperature` when this returns `True`, so for **any** other model the configured temperature is silently dropped — no warning, no error, the setting just does nothing.

That includes the local OpenAI-compatible models this project suggests in `config/secrets.py`:

```python
llm_model = ""   # Examples: "gpt-3.5-turbo", "gpt-4o", "llama-3.2-3b-instruct",
                 #           "qwen3:latest", "gemini-pro", "deepseek-llm:latest"
```

`llama-3.2-3b-instruct`, `qwen3:latest` and `deepseek-llm:latest` (LM Studio / Ollama, both explicitly supported per `requirements.txt` and the `llm_api_url` examples) all accept `temperature` — and all silently lose it today. So do newer OpenAI models like `gpt-4.1`, and any pinned snapshot such as `gpt-4o-2024-08-06`.

## Fix

Invert the check. Only OpenAI's **reasoning** families reject `temperature`; everything else accepts it. So deny-list `o1` / `o3` / `o4` / `gpt-5` and default to sending it.

Details that matter:

- **Exact-or-variant matching** (`model == prefix` or `model.startswith(prefix + "-")`) rather than a bare `startswith`, so unrelated names like `omni-model` or `o1lama` aren't swept up.
- **Case- and whitespace-insensitive**, since `llm_model` is free-form user config.
- **Strips a `provider/` prefix** so OpenRouter/LiteLLM style ids like `openai/o3-mini` are still recognised.

The failure modes are deliberately asymmetric: sending `temperature` to a model that rejects it is a hard API error, while omitting it for a model that accepts it just falls back to the default. Anything ambiguous therefore errs toward *not* sending it — e.g. `gpt-5-chat-latest` is treated as a reasoning model.

This keeps the behaviour that closed #42 (o3-mini no longer errors) while fixing the models that were caught in the blast radius.

## Verification

20 model names, comparing old vs new:

| Model | Old | New | |
|---|---|---|---|
| `gpt-4o`, `gpt-4`, `gpt-3.5-turbo`, `gpt-4o-mini` | ✅ | ✅ | unchanged |
| `gpt-4.1` | ❌ | ✅ | **fixed** |
| `gpt-4o-2024-08-06` | ❌ | ✅ | **fixed** (pinned snapshot) |
| `llama-3.2-3b-instruct` | ❌ | ✅ | **fixed** (LM Studio, in `secrets.py`) |
| `qwen3:latest` | ❌ | ✅ | **fixed** (Ollama, in `secrets.py`) |
| `deepseek-llm:latest` | ❌ | ✅ | **fixed** (Ollama, in `secrets.py`) |
| `o1`, `o1-mini`, `o3-mini`, `o3-mini-2025-01-31`, `o4-mini`, `gpt-5`, `gpt-5-mini` | ❌ | ❌ | correctly still excluded |
| `openai/o3-mini` | ❌ | ❌ | prefix handled |
| `  O3-Mini  ` | ❌ | ❌ | case/whitespace handled |
| `omni-model`, `o1lama` | ❌ | ✅ | **fixed** — must not match `o1`/`o3` |

**0 failures, 0 regressions.** Every model the old allow-list supported still gets `temperature`; no reasoning model gained it.
