### PR TITLE
Add opt-in strict mode: skip jobs silent on visa sponsorship

### DIFF
--- a/config/search.py
+++ b/config/search.py
@@ -108,6 +108,18 @@ sponsorship_offered_phrases = ["visa sponsorship available", "sponsorship availa
 # A description that says nothing about sponsorship is applied to - silence is not a refusal.
 sponsorship_unavailable_phrases = ["will not sponsor", "do not sponsor", "does not sponsor", "cannot sponsor", "unable to sponsor", "not able to sponsor", "not offer sponsorship", "not provide sponsorship", "does not provide immigration", "no visa sponsorship", "without sponsorship", "without the need for sponsorship", "sponsorship not available", "sponsorship is not available", "not eligible for visa sponsorship", "must be a us citizen", "must be a u.s. citizen"]     # (dynamic multiple search) Case Insensitive.
 
+
+# STRICT MODE: also skip jobs whose description says NOTHING about sponsorship either way?
+# Only does anything when require_visa = "Yes" AND skip_non_sponsoring_jobs = True.
+# True  = apply only where sponsorship is affirmatively offered. Most postings never mention
+#         sponsorship at all, so this skips a LOT of jobs, including many employers who would
+#         in fact have sponsored you. Silence is not a refusal.
+# False = (default) silence is treated as "maybe", and the job is applied to.
+# Why anyone would turn it on: LinkedIn caps Easy Apply at roughly 25 applications a day, so
+# applications are a rationed daily resource. If your runs end on the daily limit, a slot
+# spent on a silent posting is a slot denied to one that says "we sponsor". If your runs
+# never hit the cap, leave this off - every skip is then pure loss.
+skip_jobs_without_sponsorship = False   # True or False, Note: True or False are case-sensitive
 security_clearance = False         # True or False, Note: True or False are case-sensitive
 
 # Do you have a Masters degree? (True for Yes and False for No). If True, the tool will apply to jobs containing the word 'master' in their job description and if it's experience required <= current_experience + 2 and current_experience is not set as -1. 

--- a/config_schema.py
+++ b/config_schema.py
@@ -242,6 +242,8 @@ SCHEMA = [
                "Checked first, and an offer always wins - real postings say both. Example: we will sponsor, H-1B transfer, cap-exempt."),
             _f("Filters", "search", "sponsorship_unavailable_phrases", "Phrases that mean they do NOT sponsor", "list",
                "Matched as whole phrases, never substrings, so 'sponsorship of our annual conference' is safe. Example: unable to sponsor, without sponsorship, not eligible for visa sponsorship."),
+            _f("Filters", "search", "skip_jobs_without_sponsorship", "Also skip jobs that say nothing about sponsorship", "bool",
+               "Strict mode. Only does anything when the setting above is on. Applies only where sponsorship is explicitly offered - most postings never mention it either way, so this skips a lot of jobs, including employers who would have sponsored. Worth it only if your runs end on LinkedIn's ~25/day Easy Apply limit, where a slot spent on a silent posting is a slot denied to one that says 'we sponsor'."),
         ],
     },
     {

--- a/runAiBot.py
+++ b/runAiBot.py
@@ -602,7 +602,14 @@ def get_job_description(
         # offer always wins, because real postings say both - "we do not require you to have
         # sponsorship ... we will sponsor H-1B transfers" is an offer, not a refusal. Whole
         # phrases via find_bad_word, so "sponsorship of our annual conference" is not one
-        # either. Silence means APPLY: a wrong skip costs a real job, a wrong apply costs 30s.
+        # either. Silence means APPLY by default: silence is not a refusal, and most postings
+        # are silent. That is a default, not a law - this bot is built to run until LinkedIn's
+        # daily Easy Apply cap fires (dailyEasyApplyLimitReached), so applications are
+        # RATIONED: a wrong apply costs a slot, a wrong skip costs a slot's worth of chance.
+        # Both errors are the same currency, which is why the third state is a user setting
+        # and not a hardcoded choice - see skip_jobs_without_sponsorship. It stays OFF by
+        # default because recall is worst for the seed/Series-A companies most likely to be
+        # silent yet sponsor.
         # ponytail: JD text only. Whether the EMPLOYER has ever sponsored (tier 2, the DOL
         # LCA index) is deliberately not built here - absence from that data is not evidence.
         if (not skip and require_visa == "Yes" and skip_non_sponsoring_jobs
@@ -611,6 +618,10 @@ def get_job_description(
             if no_sponsorship:
                 skipMessage = f'\n{jobDescription}\n\nSays "{no_sponsorship}" and offers no sponsorship. Skipping this job!\n'
                 skipReason = f'Job description excludes visa sponsorship ("{no_sponsorship}")'
+                skip = True
+            elif skip_jobs_without_sponsorship:
+                skipMessage = f'\n{jobDescription}\n\nSays nothing either way about sponsorship. Skipping this job (strict mode)!\n'
+                skipReason = "Job description is silent on visa sponsorship (not a refusal)"
                 skip = True
         # Whole words: substring 'clearance' matched "clearance sale" and 'secret' matched
         # "secretary", skipping jobs that had nothing to do with a clearance. Same bug class

--- a/tests/test_h1b_sponsorship.py
+++ b/tests/test_h1b_sponsorship.py
@@ -9,8 +9,11 @@ What it must get right, and why each case is here:
 * No substring matching. This codebase has shipped five naive-substring bugs already
   ('state' in "United States", 'no' in "Non-citizen", 'java' in "JavaScript"). Matching
   goes through find_bad_word, so "sponsorship of our annual conference" is not a refusal.
-* Silence means APPLY. Most postings say nothing about sponsorship. Absence of evidence is
-  never a skip: a wrong skip costs a real job, a wrong apply costs thirty seconds.
+* Silence means APPLY *by default*. Most postings say nothing about sponsorship, and
+  silence is not a refusal. It is a default, not a law: LinkedIn rations Easy Apply at
+  ~25/day, so a wrong apply costs a slot and a wrong skip costs a slot's worth of chance -
+  same currency. skip_jobs_without_sponsorship is the opt-in that flips it, and the tests
+  below pin both states, including that it cannot bypass skip_non_sponsoring_jobs.
 * Inert unless asked for. require_visa != "Yes" or skip_non_sponsoring_jobs = False must
   change nothing at all.
 
@@ -64,6 +67,7 @@ def pinned_config(bot, monkeypatch):
     '''Pin every setting the assertions depend on, and keep the other filters out of it.'''
     monkeypatch.setattr(bot, "require_visa", "Yes")
     monkeypatch.setattr(bot, "skip_non_sponsoring_jobs", True)
+    monkeypatch.setattr(bot, "skip_jobs_without_sponsorship", False)   # strict mode off = shipped default
     monkeypatch.setattr(bot, "sponsorship_offered_phrases", OFFERED)
     monkeypatch.setattr(bot, "sponsorship_unavailable_phrases", UNAVAILABLE)
     monkeypatch.setattr(bot, "bad_words", [])                 # no bad-word skip
@@ -173,6 +177,61 @@ def test_nothing_is_skipped_while_the_setting_is_off(bot, monkeypatch):
     assert reason is None
 
 
+# ------------------------------ strict mode: skip on silence -----------------------------
+SILENT = "Senior Python engineer. You will own our data pipeline and mentor two juniors."
+
+
+@pytest.fixture
+def strict(bot, monkeypatch):
+    monkeypatch.setattr(bot, "skip_jobs_without_sponsorship", True)
+
+
+def test_strict_mode_skips_a_posting_that_says_nothing_about_sponsorship(bot, monkeypatch, strict):
+    skip, reason, message = scan(bot, monkeypatch, SILENT)
+
+    assert skip is True
+    # Silence and refusal are different facts and the user has to be able to tell them apart
+    # in the log and in the CSV, or a tunable false positive looks like an untunable one.
+    assert "silent" in reason.lower()
+    assert "not a refusal" in reason.lower()
+    assert "excludes visa sponsorship" not in reason      # that wording is for an actual refusal
+    assert message
+
+
+def test_strict_mode_still_applies_when_sponsorship_is_offered(bot, monkeypatch, strict):
+    skip, reason, _message = scan(bot, monkeypatch,
+        "This role is cap-exempt and we sponsor H-1B transfers.")
+
+    assert skip is False
+    assert reason is None
+
+
+def test_strict_mode_reports_a_refusal_as_a_refusal_not_as_silence(bot, monkeypatch, strict):
+    skip, reason, _message = scan(bot, monkeypatch, REFUSAL)
+
+    assert skip is True
+    assert "not eligible for visa sponsorship" in reason
+    assert "silent" not in reason.lower()
+
+
+def test_strict_mode_is_inert_when_the_user_does_not_need_sponsorship(bot, monkeypatch, strict):
+    monkeypatch.setattr(bot, "require_visa", "No")
+
+    skip, reason, _message = scan(bot, monkeypatch, SILENT)
+
+    assert skip is False
+    assert reason is None
+
+
+def test_strict_mode_cannot_bypass_the_master_switch(bot, monkeypatch, strict):
+    '''skip_non_sponsoring_jobs is the master switch. Strict mode is a modifier on it, not a
+    second way in - off means the whole filter is off, however strict mode is set.'''
+    monkeypatch.setattr(bot, "skip_non_sponsoring_jobs", False)
+
+    assert scan(bot, monkeypatch, SILENT) == (False, None, None)
+    assert scan(bot, monkeypatch, REFUSAL) == (False, None, None)
+
+
 # --------------- the settings must exist and be tunable without editing code -------------
 def test_the_settings_exist_in_the_config_file(bot):
     '''Existence only. The user's own values are his to set, so nothing here asserts them -
@@ -180,5 +239,6 @@ def test_the_settings_exist_in_the_config_file(bot):
     import config.search as search
 
     assert isinstance(search.skip_non_sponsoring_jobs, bool)
+    assert search.skip_jobs_without_sponsorship is False   # strict mode ships OFF, non-negotiable
     assert search.sponsorship_offered_phrases          # tunable without editing code
     assert search.sponsorship_unavailable_phrases


### PR DESCRIPTION
Completes the three-state sponsorship model started in #128. No dataset, no
network, no new dependency — it reads the job description the bot already fetches.

| State | Evidence | Behaviour |
|---|---|---|
| Offers sponsorship | an offer phrase in the JD | apply |
| Refuses sponsorship | a refusal phrase in the JD | skip (shipped in #128) |
| **Silent** | neither | apply by default; **skip if strict mode is on** |

`skip_jobs_without_sponsorship` defaults to **False**, so nothing changes for
anyone who does not turn it on. It also cannot bypass the master switch: it does
nothing unless `require_visa = "Yes"` AND `skip_non_sponsoring_jobs = True`.

Silence and refusal are logged and recorded as **different** skip reasons, so a
user can tell "they said no" from "they said nothing" in the CSV.

### Why this is a setting and not a decision the tool makes

The comment justifying the old behaviour claimed a wrong skip costs a real job
while a wrong apply costs 30 seconds. That was wrong, and it is corrected here.
This bot is built to run until LinkedIn's daily Easy Apply cap fires (see
`dailyEasyApplyLimitReached`), so applications are a **rationed** daily resource
of roughly 25. A wrong apply costs a slot; a wrong skip costs a slot's worth of
chance. Both errors are in the same currency, so the trade-off genuinely depends
on whether a given user's runs hit the cap — which is exactly the shape of a
setting, not a hardcoded choice.

It stays off by default because recall is worst for the seed and Series-A
companies most likely to be silent *and* sponsor.

223 passing tests, up from 218. Each new test was verified to go red when the
gate is broken.
