### PR TITLE
docs: split the 346-line README into a docs/ folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,49 +1,168 @@
 # Contributing
 
-Thanks for your interest in contributing to **Auto_job_applier_linkedIn**! All
-contributions are welcome, no matter how small or large.
+Thank you for your efforts and for being a part of the community. All contributions are
+appreciated no matter how small or big. Once you contribute to the code base, your work will
+be remembered forever.
 
-## 1. Follow the existing code guidelines
+## Where to send pull requests
 
-This project already documents its code style, naming conventions, configuration-variable
-rules, and an optional attestation format for crediting contributions. Please read and follow the
-**Contributor Guidelines** section of the [README](README.md#-contributor-guidelines)
-rather than duplicating it here. In particular:
+> **NOTE:** Only pull requests to the `community-version` branch will be accepted. Any other
+> requests will be declined by default, especially to the `main` branch.
 
-- **Code guidelines** — function naming/docstrings/type hints, variable naming, and
-  configuration-variable rules: see [README → Code Guidelines](README.md#code-guidelines).
-- **Attestation (optional)** — you may add an attestation marker above your code to
-  credit yourself, in the form:
+Once your code is tested, your changes will be merged to the `main` branch in the next cycle.
 
-  ```python
-  ##> ------ <Your full name> : <github id> OR <email> - <Type of change> ------
-      # your code
-  ##<
-  ```
+## Code guidelines
 
-  It is optional and used only for credit. Past contributors are acknowledged in
-  [`docs/contributor-consent/contributors.md`](docs/contributor-consent/contributors.md).
+### Functions
 
-## 2. Where to send pull requests
+1. All functions or methods are named lower case and snake case.
+2. Must have an explanation of their purpose. Write the explanation surrounded in
+   `''' Explanation '''` under the definition `def function() -> None:`. Example:
 
-Per the README, **pull requests should target the `community-version` branch**, not
-`main`. PRs to other branches (especially `main`) are declined by default. Once your
-change is tested, it is merged into `main` in the next cycle. See
-[README → Contributor Guidelines](README.md#-contributor-guidelines) for details.
+    ```python
+    def function() -> None:
+      '''
+      This function does nothing, it's just an example for explanation placement!
+      '''
+    ```
 
-## 3. Quick checklist before opening a PR
+3. The types `(str, list, int, list[str], int | float)` for the parameters and returns must
+   be given. Example:
+
+    ```python
+    def function(param1: str, param2: list[str], param3: int) -> str:
+    ```
+
+4. Putting all that together, some valid examples for function or method declarations would
+   be as follows.
+
+    ```python
+    def function_name_in_camel_case(parameter1: driver, parameter2: str) -> list[str] | ValueError:
+      '''
+      This function is an example for code guidelines
+      '''
+      return [parameter2, parameter2.lower()]
+    ```
+
+5. The hashtag comments on top of functions are optional, and are intended for developers
+   `# Comments for developers`.
+
+    ```python
+    # Enter input text function
+    def text_input_by_ID(driver: WebDriver, id: str, value: str, time: float=5.0) -> None | Exception:
+        '''
+        Enters `value` into the input field with the given `id` if found, else throws NotFoundException.
+        - `time` is the max time to wait for the element to be found.
+        '''
+        username_field = WebDriverWait(driver, time).until(EC.presence_of_element_located((By.ID, id)))
+        username_field.send_keys(Keys.CONTROL + "a")
+        username_field.send_keys(value)
+    ```
+
+### Variables
+
+1. All variables must start with lower case and must be in explainable full words. If
+   someone reads the variable name, it should be easy to understand what the variable
+   stores.
+2. All local variables are camel case. Examples:
+
+    ```python
+    jobListingsElement = None
+    ```
+
+    ```python
+    localBufferTime = 5.5
+    ```
+
+3. All global variables are snake case. Example:
+
+    ```
+    total_runs = 1
+    ```
+
+4. Mentioning types is optional.
+
+    ```python
+    localBufferTime: float | int = 5.5
+    ```
+
+### Configuration variables
+
+1. All config variables are treated as global variables. They have some extra guidelines.
+2. Must have a variable setting explanation, and examples of valid values. Examples:
+
+    ```python
+    # Explanation of what this setting will do, and instructions to enter it correctly
+    config_variable = "value1"    #  <Valid values examples, and NOTES> "value1", "value2", etc. Don't forget quotes ("")
+    ```
+
+    ```python
+    # Do you want to randomize the search order for search_terms?
+    randomize_search_order = False     # True of False, Note: True or False are case-sensitive
+    ```
+
+    ```python
+    # Avoid applying to jobs if their required experience is above your current_experience. (Set value as -1 if you want to apply to all ignoring their required experience...)
+    current_experience = 5             # Integers > -2 (Ex: -1, 0, 1, 2, 3, 4...)
+    ```
+
+    ```python
+    # Search location, this will be filled in "City, state, or zip code" search box. If left empty as "", tool will not fill it.
+    search_location = "United States"               # Some valid examples: "", "United States", "India", "Chicago, Illinois, United States", "90001, Los Angeles, California, United States", "Bengaluru, Karnataka, India", etc.
+    ```
+
+3. Add the config variable to the appropriate `/config/` file.
+4. Every config variable must be validated. Go to `/modules/validator.py` and add it there.
+   Example: for the config variable `search_location = ""` found in `/config/search.py`,
+   string validation is added in `/modules/validator.py` under the method
+   `def validate_search()`.
+
+    ```python
+    def validate_search() -> None | ValueError | TypeError:
+        '''
+        Validates all variables in the `/config/search.py` file.
+        '''
+        check_string(search_location, "search_location")
+    ```
+
+5. If the setting should also appear in the local control panel, add it to
+   `config_schema.py`. Settings left out of the schema are still fully usable by editing the
+   `config/*.py` file, and the [configuration docs](docs/configuration.md) list which ones
+   those are.
+
+## Running the tests
+
+Before opening a PR, run the test suite and make sure it passes:
+
+```
+./run_tests.sh          # macOS/Linux  (run_tests.command / run_tests.bat also work)
+# or:  python -m pytest
+```
+
+## Checklist before opening a PR
 
 - [ ] My PR targets the `community-version` branch.
-- [ ] I followed the code guidelines in the [README](README.md#-contributor-guidelines).
+- [ ] I followed the code guidelines above.
 - [ ] I ran the tests (`./run_tests.sh` or `python -m pytest`) and they pass.
 - [ ] My contribution is my own work, or I have the right to submit it, and is offered under the MIT License.
 
-## 4. Licensing of contributions
+## Licensing of contributions
 
-This project is licensed under the **MIT License** (see [`LICENSE`](LICENSE)). By
-opening a pull request, you agree that your contribution is your own work (or that
-you have the right to submit it) and that it is provided under the MIT License —
-that is, inbound contributions are under the same license as the project (inbound =
-outbound).
+This project is licensed under the **MIT License** (see [`LICENSE`](LICENSE)). By opening a
+pull request you agree that your contribution is your own work (or that you have the right
+to submit it) and that it is provided under the MIT License — inbound contributions are
+under the same license as the project (inbound = outbound). Contributors are credited
+through the Git history.
+
+Optionally, you may add an attestation comment above your code to credit yourself:
+
+```python
+##> ------ <Your full name> : <github id> OR <email> - <Type of change> ------
+    # your code
+##<
+```
+
+It is optional and used only for credit. Past contributors are acknowledged in
+[`docs/contributor-consent/contributors.md`](docs/contributor-consent/contributors.md).
 
 Thank you for helping improve the project!

--- a/README.md
+++ b/README.md
@@ -1,34 +1,33 @@
 # LinkedIn AI Auto Job Applier 🤖
-This is a free, open-source tool that automates job applications on LinkedIn. It runs entirely on your own computer, using your own LinkedIn account. It finds jobs relevant to you, fills in the application questions — optionally with AI help — and applies using the resume you provide. Can apply to 100+ jobs in under an hour. 
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Python 3.10+](https://img.shields.io/badge/Python-3.10%2B-3776AB.svg)](https://www.python.org/downloads/)
+[![Discord](https://img.shields.io/badge/Discord-join-5865F2.svg)](https://discord.gg/fFp7uUzWCY)
+[![Sponsor](https://img.shields.io/badge/Sponsor-GodsScion-EA4AAA.svg)](https://github.com/sponsors/GodsScion)
+
+A free, open-source tool that automates job applications on LinkedIn. It runs entirely on
+your own computer, using your own LinkedIn account. It finds jobs relevant to you, fills in
+the application questions — optionally with AI help — and applies using the resume you
+provide. Can apply to 100+ jobs in under an hour.
+
+Nothing is uploaded anywhere: your details stay in local files, and the control panel is
+reachable only from your own machine.
 
 ## 📽️ See it in Action
+
 [![Auto Job Applier demo video](https://github.com/GodsScion/Auto_job_applier_linkedIn/assets/100998531/429f7753-ebb0-499b-bc5e-5b4ee28c4f69)](https://youtu.be/gMbB1fWZDHw)
-Click on above image to watch the demo or use this link https://youtu.be/gMbB1fWZDHw
 
+Click the image above to watch the demo, or use this link: https://youtu.be/gMbB1fWZDHw
 
-## ✨ Content
-- [Introduction](#linkedin-ai-auto-job-applier-)
-- [Demo Video](#%EF%B8%8F-see-it-in-action)
-- [Index](#-content)
-- [Easy start (recommended)](#-easy-start-recommended)
-- [Install](#%EF%B8%8F-how-to-install)
-- [Configure](#-how-to-configure)
-- [Contributor Guidelines](#‍-contributor-guidelines)
-- [Updates](%EF%B8%8F-major-updates-history)
-- [Disclaimer](#-disclaimer)
-- [Terms and Conditions](#%EF%B8%8F-terms-and-conditions)
-- [License](#%EF%B8%8F-license)
-- [Socials](#-socials)
-- [Support and Discussions](#-community-support-and-discussions)
+## 🚀 Quick start
 
-<br>
+New here, or not comfortable editing code? Use the built-in control panel. You set
+everything up in your web browser and run the tool with a button — no editing Python files,
+no terminal commands.
 
-## 🚀 Easy start (recommended)
-
-New here, or not comfortable editing code? Use the built-in control panel. You set everything up in your web browser and run the tool with a button - no editing Python files, no terminal commands.
-
-1. **Install Python once.** Get it from https://www.python.org/downloads/ (on Windows, tick **"Add Python to PATH"** during install). You also need [Google Chrome](https://www.google.com/chrome).
+1. **Install Python once.** Get it from https://www.python.org/downloads/ (on Windows, tick
+   **"Add Python to PATH"** during install). You also need
+   [Google Chrome](https://www.google.com/chrome).
 2. **Download this project** (green "Code" button → "Download ZIP", then unzip; or clone it).
 3. **Double-click the launcher for your system:**
     - **macOS:** `start.command`
@@ -36,311 +35,62 @@ New here, or not comfortable editing code? Use the built-in control panel. You s
     - **Linux:** `start.sh` (run `./start.sh` in a terminal)
 
     The first run sets things up automatically (it may take a minute). After that it's quick.
-4. Your browser opens the **control panel** automatically (the exact address, e.g. `http://127.0.0.1:5000`, is shown in the launcher window). Fill in the tabs - **Account, Profile, Search, Filters, Run settings** - and click **Save**.
-5. Go to the **Run** tab and click **Start**. A Chrome window opens and begins applying - keep it in the foreground. You can watch progress in the log and click **Stop** any time.
+4. Your browser opens the **control panel** automatically (the exact address, e.g.
+   `http://127.0.0.1:5000`, is shown in the launcher window). Fill in the tabs —
+   **Account, Profile, Search, Filters, Run settings** — and click **Save**.
+5. Go to the **Run** tab and click **Start**. A Chrome window opens and begins applying —
+   keep it in the foreground. You can watch progress in the log and click **Stop** any time.
 
-Everything stays on your own computer: your details are saved locally in `user_config.json` (never uploaded), and the control panel is reachable only from this machine. If you prefer the classic setup, the manual steps below still work exactly as before.
+Your settings are saved locally in `user_config.json`. If you prefer the classic setup,
+editing `config/*.py` by hand still works exactly as before — see
+[Installation](docs/install.md) and [Configuration](docs/configuration.md).
 
-[back to index](#-content)
+> **Tip for your first run:** set `stop_before_submit = True` in `config/settings.py` to have
+> the tool fill in every application and stop at the Review step without submitting, so you
+> can see what it would say before you trust it.
+> [More on dry runs](docs/config-settings.md#dry-runs-stop_before_submit).
 
-<br>
+## 📚 Documentation
 
-## ⚙️ How to install
+Full documentation lives in **[`docs/`](docs/README.md)**.
 
-[![Auto Job Applier setup tutorial video](https://github.com/user-attachments/assets/9e876187-ed3e-4fbf-bd87-4acc145880a2)](https://youtu.be/f9rdz74e1lM?si=4fRBcte0nuvr6tEH)
-Click on above image to watch the tutorial for installation and configuration or use this link https://youtu.be/f9rdz74e1lM (Recommended to watch it in 2x speed)
+| | |
+|---|---|
+| [Installation](docs/install.md) | Python, Chrome, packages, the Chrome driver, running the bot and the control panel |
+| [Configuration](docs/configuration.md) | How configuration works and the order to do it in |
+| → [`personals.py`](docs/config-personals.md) | Your name, phone, address, equal-opportunity answers |
+| → [`questions.py`](docs/config-questions.md) | Easy Apply answers: experience, work authorization, salary, notice period, resume |
+| → [`search.py`](docs/config-search.md) | Search terms, LinkedIn filters, skip rules, visa-sponsorship filtering |
+| → [`secrets.py`](docs/config-secrets.md) | LinkedIn login and the optional AI setup |
+| → [`settings.py`](docs/config-settings.md) | How the bot runs: click gap, background mode, safe mode, dry runs |
+| [Contributing](CONTRIBUTING.md) | Code guidelines, where to send PRs, running the tests |
+| [Support and community](docs/support.md) | Discord, GitHub Discussions, socials, sponsoring |
+| [Disclaimer, Terms and License](docs/legal.md) | Read this before you use the tool |
 
-1. [Python 3.10](https://www.python.org/) or above. Visit https://www.python.org/downloads/ to download and install Python, or for windows you could visit Microsoft Store and search for "Python". **Please make sure Python is added to Path in System Environment Variables**.
-2. Install the required Python packages. After Python is installed, open a console/terminal in the project folder and run the command below (it uses [pip](https://pip.pypa.io/en/stable) to install everything listed in `requirements.txt`).
-  ```
-  pip install -r requirements.txt
-  ```
-3. Download and install latest version of [Google Chrome](https://www.google.com/chrome) in it's default location, visit https://www.google.com/chrome to download it's installer.
-4. Clone the current git repo or download it as a zip file, url to the latest update https://github.com/GodsScion/Auto_job_applier_linkedIn.
-5. Chrome Driver is taken care of for you: `auto_manage_driver = True` (the default in `config/settings.py`) downloads the matching driver automatically. If you'd rather manage it yourself, set it to `False` and place the matching [Chrome Driver](https://googlechromelabs.github.io/chrome-for-testing/) where Chrome is installed.
-6. If you have questions or need help setting it up or to talk in general, join the github server: https://discord.gg/fFp7uUzWCY
+Version history and release notes are on the
+[Releases page](https://github.com/GodsScion/Auto_job_applier_linkedIn/releases).
 
-[back to index](#-content)
+## 🙌 Community and socials
 
-<br>
+- **Discord server**: https://discord.gg/fFp7uUzWCY — the fastest place to get help
+- **GitHub Discussions**: https://github.com/GodsScion/Auto_job_applier_linkedIn/discussions
+- **LinkedIn**: https://www.linkedin.com/in/saivigneshgolla/
+- **X/Twitter**: https://x.com/saivigneshgolla
+- **Email**: saivigneshgolla@outlook.com
 
-## 🔧 How to configure
-1. Open `personals.py` file in `/config` folder and enter your details like name, phone number, address, etc. Whatever you want to fill in your applications.
-2. Open `questions.py` file in `/config` folder and enter your answers for application questions, configure wether you want the bot to pause before submission or pause if it can't answer unknown questions.
-3. Open `search.py` file in `/config` folder and enter your search preferences, job filters, configure the bot as per your needs (these settings decide which jobs to apply for or skip).
-4. Open `secrets.py` file in `/config` folder and enter your LinkedIn username and password (optional — if you leave them as default, it logs in with the browser's saved profile, or asks you to log in manually). This file is also where you turn on optional AI help and choose your provider, model, key and URL — see [AI setup](#-ai-setup-optional) below.
-5. Open `settings.py` file in `/config` folder to configure settings like keep screen awake, click interval (time to wait between actions), run in background, automatic Chrome-driver management, etc. as per your needs.
-6. (Optional) Add your default resume at the path set by `default_resume_path` (e.g. `all resumes/default/resume.pdf`) in `/config/questions.py`. If one isn't provided, the tool uses your most recent resume already uploaded to LinkedIn.
-7. Run `runAiBot.py` and see the magic happen.
-8. To run the local control panel (settings, run controls, and Applied Jobs history), run `app.py` - it prints the address to open (e.g. `http://127.0.0.1:5000`, or another port if 5000 is busy).
-8. If you have questions or need help setting it up or to talk in general, join the github server: https://discord.gg/fFp7uUzWCY
-
-### 🤖 AI setup (optional)
-
-AI is **off by default**. When it's on, it helps answer free-text application questions and can read the required skills out of a job description. It's provider-agnostic (built on LangChain + LangGraph), so one set of options in `config/secrets.py` covers every provider:
-
-- `use_AI` — set to `True` to enable AI.
-- `ai_provider` — `"openai"`, `"gemini"`, or `"deepseek"`. Use `"openai"` for OpenAI **or** any OpenAI-compatible server, including local ones like [Ollama](https://ollama.com/) and [LM Studio](https://lmstudio.ai/).
-- `llm_model` — the model name, e.g. `gpt-4o-mini`, `gemini-2.5-flash`, or a local model like `qwen2.5:latest`.
-- `llm_api_key` — your provider's API key. For local servers, leave it as `"not-needed"`.
-- `llm_api_url` — the server URL (used by the OpenAI provider family only), e.g. `https://api.openai.com/v1/`, `http://localhost:11434/v1/` (Ollama), or `https://api.deepseek.com/v1`.
-
-You can set all of this from the control panel's **Account** tab instead of editing the file.
-
-[back to index](#-content)
-
-<br>
-
-
-## 🧑‍💻 Contributor Guidelines
-Thank you for your efforts and being a part of the community. All contributions are appreciated no matter how small or big. Once you contribute to the code base, your work will be remembered forever.
-
-NOTE: Only Pull request to `community-version` branch will be accepted. Any other requests will be declined by default, especially to main branch.
-Once your code is tested, your changes will be merged to the `main` branch in next cycle.
-
-### Code Guidelines
-  #### Functions:
-  1. All functions or methods are named lower case and snake case
-  2. Must have explanation of their purpose. Write explanation surrounded in `''' Explanation '''` under the definition `def function() -> None:`. Example:
-      ```python
-      def function() -> None:
-        '''
-        This function does nothing, it's just an example for explanation placement!
-        '''
-      ```
-  4. The Types `(str, list, int, list[str], int | float)` for the parameters and returns must be given. Example:
-      ```python
-      def function(param1: str, param2: list[str], param3: int) -> str:
-      ```
-  5. Putting all that together some valid examples for function or method declarations would be as follows.
-      ```python
-      def function_name_in_camel_case(parameter1: driver, parameter2: str) -> list[str] | ValueError:
-        '''
-        This function is an example for code guidelines
-        '''
-        return [parameter2, parameter2.lower()]
-      ```
-  6. The hashtag comments on top of functions are optional, which are intended for developers `# Comments for developers`.
-      ```python
-      # Enter input text function
-      def text_input_by_ID(driver: WebDriver, id: str, value: str, time: float=5.0) -> None | Exception:
-          '''
-          Enters `value` into the input field with the given `id` if found, else throws NotFoundException.
-          - `time` is the max time to wait for the element to be found.
-          '''
-          username_field = WebDriverWait(driver, time).until(EC.presence_of_element_located((By.ID, id)))
-          username_field.send_keys(Keys.CONTROL + "a")
-          username_field.send_keys(value)
-      
-      ```
-   
-  #### Variables
-  1. All variables must start with lower case, must be in explainable full words. If someone reads the variable name, it should be easy to understand what the variable stores.
-  2. All local variables are camel case. Examples:
-      ```python
-      jobListingsElement = None
-      ```
-      ```python
-      localBufferTime = 5.5
-      ```
-  3. All global variables are snake case. Example:
-      ```
-      total_runs = 1
-      ```
-  4. Mentioning types are optional.
-      ```python
-      localBufferTime: float | int = 5.5
-      ```
-  
-  #### Configuration variables
-  1. All config variables are treated as global variables. They have some extra guidelines.
-  2. Must have variable setting explanation, and examples of valid values. Examples:
-      ```python
-      # Explanation of what this setting will do, and instructions to enter it correctly
-      config_variable = "value1"    #  <Valid values examples, and NOTES> "value1", "value2", etc. Don't forget quotes ("")
-      ```
-      ```python
-      # Do you want to randomize the search order for search_terms?
-      randomize_search_order = False     # True of False, Note: True or False are case-sensitive
-      ```
-      ```python
-      # Avoid applying to jobs if their required experience is above your current_experience. (Set value as -1 if you want to apply to all ignoring their required experience...)
-      current_experience = 5             # Integers > -2 (Ex: -1, 0, 1, 2, 3, 4...)
-      ```
-      ```python
-      # Search location, this will be filled in "City, state, or zip code" search box. If left empty as "", tool will not fill it.
-      search_location = "United States"               # Some valid examples: "", "United States", "India", "Chicago, Illinois, United States", "90001, Los Angeles, California, United States", "Bengaluru, Karnataka, India", etc.
-
-      ```
-  4. Add the config variable in appropriate `/config/file`.
-  5. Every config variable must be validated. Go to `/modules/validator.py` and add it over there. Example:
-      For config variable `search_location = ""` found in `/config/search.py`, string validation is added in file `/modules/validator.py` under the method `def validate_search()`.
-      ```python
-      def validate_search() -> None | ValueError | TypeError:
-          '''
-          Validates all variables in the `/config/search.py` file.
-          '''
-          check_string(search_location, "search_location")
-      ```
-
-  [back to index](#-content)
-  
-  ### Running the tests
-
-  Before opening a PR, run the test suite and make sure it passes:
-
-  ```
-  ./run_tests.sh          # macOS/Linux  (run_tests.command / run_tests.bat also work)
-  # or:  python -m pytest
-  ```
-
-  ### Licensing of contributions
-
-  This project is licensed under the **MIT License**. By opening a pull request you agree that your contribution is your own work (or that you have the right to submit it) and that it is provided under the MIT License — inbound contributions are under the same license as the project (inbound = outbound). Contributors are credited through the Git history.
-
-  Optionally, you may add an attestation comment above your code to credit yourself:
-
-  ```python
-  ##> ------ <Your full name> : <github id> OR <email> - <Type of change> ------
-      # your code
-  ##<
-  ```
-
-[back to index](#-content)
-
-## 🗓️ Major Updates History:
-### Aug 2026
-- Relicensed from AGPL-3.0 to the **MIT License** (see [`NOTICE`](NOTICE)).
-- Rebuilt the AI layer on **LangChain + LangGraph** — one provider-agnostic path for OpenAI, OpenAI-compatible servers (Ollama, LM Studio, DeepSeek), and Google Gemini.
-- Added a unit + integration **test suite** (`./run_tests.sh` or `python -m pytest`).
-- Removed unused in-development scaffolding (resume-generation stubs, legacy setup scripts).
-
-### Jan 20, 2026
-- You can now simultaneously use chrome, while bot continues applying in a new window
-
-### Jul 20, 2024
-- Contributions from community have been added
-- Better AI support, minor bug fixes
-
-### Nov 28, 2024
-- Patched to work for latest changes in Linkedin.
-- Users can now select to follow or not follow companies when submitting application.
-- Frameworks for future AI Developments have been added.
-- AI can now be used to extract skills from job description. 
-
-### Oct 16, 2024
-- Framework for OpenAI API and Local LLMs
-- Framework for RAG
-
-### Sep 09, 2024
-- Smarter Auto-fill for salaries and notice periods
-- Robust Search location filter, will work in window mode (No need for full screen)
-- Better logic for Select and Radio type questions
-- Proper functioning of Decline to answer questions in Equal Employment opportunity questions
-- Checkbox questions select fail bug fixed
-- Annotations are clearer in instructions for setup
-
-### Sep 07, 2024
-- Annotations for developers
-- Robust input validations
-- Restructured config file
-- Fixed pagination bug
-
-### Aug 21, 2024
-- Performance improvements (skip clicking on applied jobs and blacklisted companies)
-- Stop when easy apply application limit is reached
-- Added ability to discard from pause at submission dialogue box
-- Added support for address input
-- Bug fixed radio questions, added support for physical disability questions
-- Added framework for future config file updates
-
-### June 19, 2024
-- Major Bug fixes (Text Area type questions)
-- Made uploading default resume as not required
-
-### May 15, 2024
-- Added functionality for textarea type questions `summary`, `cover_letter`(Summary, Cover letter); checkbox type questions (acknowledgements)
-- Added feature to skip irrelevant jobs based on `bad_words` 
-- Improved performance for answering questions
-- Logic change for masters students skipping
-- Change variable names `blacklist_exceptions` -> `about_company_good_words` and `blacklist_words` -> `about_company_bad_words`
-- Added session summary for logs
-- Added option to turn off "Pause before Submit" until next run
-
-### May 05, 2024
-- For questions similar to "What is your current location?", City posted in Job description will be posted as the answer if `current_city` is left empty in the configuration
-- Added option to over write previously saved answers for a question `overwrite_previous_answers`
-- Tool will now save previous answer of a question
-- Tool will now collect all available options for a Radio type or Select type question
-- Major update in answering logic for Easy Apply Application questions
-- Added Safe mode option for quick stable launches `safe_mode`
-
-### May 04, 2024
-- Added option to fill in "City, state, or zip code" search box `search_location`
-- Bug fixes in answering City or location question
-
-
-[back to index](#-content)
-
-<br>
+If this tool helped you, please share it with your peers, or
+[sponsor the project](https://github.com/sponsors/GodsScion). It is built by one independent
+developer.
 
 ## 📜 Disclaimer
 
-**This tool runs on your own computer and acts through your own accounts. It is provided free and open source, with no warranty of any kind. You are responsible for how you use it, including making sure your use complies with the terms of any website or service you use it with. The authors and contributors accept no liability for how it is used.**
-
-
-## 🏛️ Terms and Conditions
-
-Please consider the following:
-
-- **LinkedIn Policies**: LinkedIn has policies regarding automated activity on its platform. It is your responsibility to review and comply with them before using this tool with your account.
-
-- **No Warranties or Guarantees**: This program is provided as-is, without any warranties or guarantees of any kind. The accuracy, reliability, and effectiveness of the program cannot be guaranteed. Use it at your own risk.
-
-- **Disclaimer of Liability**: The creators and contributors of this program shall not be held responsible or liable for any damages or consequences arising from the direct or indirect use, interaction, or actions performed with this program. This includes but is not limited to any legal issues, loss of data, or other damages incurred.
-
-- **Use at Your Own Risk**: It is important to exercise caution and ensure that your usage, interactions, and actions with this program comply with applicable laws, regulations, and the terms of the services you use it with.
-
-- **Chrome Driver**: This program uses the Chrome Driver to control your browser. Please review and comply with the terms and conditions specified for [Chrome Driver](https://chromedriver.chromium.org/home).
-
+**This tool runs on your own computer and acts through your own accounts. It is provided
+free and open source, with no warranty of any kind. You are responsible for how you use it,
+including making sure your use complies with the terms of any website or service you use it
+with.** See [Disclaimer, Terms and Conditions](docs/legal.md).
 
 ## ⚖️ License
 
-Copyright (c) 2024-2026 Sai Vignesh Golla  <saivigneshgolla@outlook.com>
-
-This project is licensed under the **MIT License**. You are free to use, copy, modify, and distribute it — including in commercial and closed-source work — as long as the copyright notice and permission notice are preserved. It is provided "as is", without warranty of any kind.
-
-Releases before August 2026 were licensed under the AGPL-3.0. See [`NOTICE`](NOTICE) for the relicensing history, and the [`LICENSE`](LICENSE) file for the full MIT text.
-
-
-<br>
-
-[back to index](#-content)
-
-<br>
-
-## 🐧 Socials
-- **LinkedIn** : https://www.linkedin.com/in/saivigneshgolla/
-- **Email**    : saivigneshgolla@outlook.com
-- **X/Twitter**: https://x.com/saivigneshgolla
-- **Discord**  : godsscion
-
-
-## 🙌 Community Support and Discussions
-- **Discord Server** : https://discord.gg/fFp7uUzWCY
-alternate link: https://discord.gg/ykfDjRFB
-- **GitHub**
-    - [All Discussions](https://github.com/GodsScion/Auto_job_applier_linkedIn/discussions)
-    - [Announcements](https://github.com/GodsScion/Auto_job_applier_linkedIn/discussions/categories/announcements)
-    - [General](https://github.com/GodsScion/Auto_job_applier_linkedIn/discussions/categories/general)
-    - [Feature requests or Ideas](https://github.com/GodsScion/Auto_job_applier_linkedIn/discussions/categories/feature-requests-or-ideas)
-    - [Polls](https://github.com/GodsScion/Auto_job_applier_linkedIn/discussions/categories/polls)
-    - [Community Flex](https://github.com/GodsScion/Auto_job_applier_linkedIn/discussions/categories/community-flex)
-    - [Support Q&A](https://github.com/GodsScion/Auto_job_applier_linkedIn/discussions/categories/support-q-a)
-
-
-#### ℹ️ Version: 26.01.20.5.08
-
----
-
-[back to the top](#linkedin-ai-auto-job-applier-)
+Copyright (c) 2024-2026 Sai Vignesh Golla. Licensed under the **MIT License** — see
+[`LICENSE`](LICENSE). Releases before August 2026 were AGPL-3.0; see [`NOTICE`](NOTICE) for
+the relicensing history.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,37 @@
+# Documentation
+
+Everything about the LinkedIn AI Auto Job Applier that does not fit on the
+[front page](../README.md).
+
+## Getting started
+
+| Page | What is in it |
+|---|---|
+| [Installation](install.md) | Python, Chrome, the packages, the Chrome driver, and how to run the bot and the control panel |
+| [Configuration](configuration.md) | How configuration works, the order to do it in, and the rules that apply to every config file |
+
+## Configuration reference
+
+One page per file in `config/`.
+
+| Page | Covers |
+|---|---|
+| [`config/personals.py`](config-personals.md) | Name, phone, address, equal-opportunity answers |
+| [`config/questions.py`](config-questions.md) | Easy Apply answers: experience, work authorization, salary, notice period, resume, pause behaviour |
+| [`config/search.py`](config-search.md) | Search terms, LinkedIn filters, skip rules, visa-sponsorship filtering |
+| [`config/secrets.py`](config-secrets.md) | LinkedIn login and the optional AI setup |
+| [`config/settings.py`](config-settings.md) | How the bot runs: click gap, background mode, safe mode, dry runs, logs |
+
+## Project
+
+| Page | What is in it |
+|---|---|
+| [Contributing](../CONTRIBUTING.md) | Code guidelines, where to send pull requests, running the tests, licensing of contributions |
+| [Contributors and the MIT relicense record](contributor-consent/contributors.md) | Acknowledgements for the AGPL-era contributors, and how the relicense was done |
+| [Disclaimer, Terms and License](legal.md) | Read this before you use the tool |
+| [Support and community](support.md) | Discord, GitHub Discussions, socials, sponsoring |
+| [Releases](https://github.com/GodsScion/Auto_job_applier_linkedIn/releases) | Version history and release notes |
+
+---
+
+[← Back to the project README](../README.md)

--- a/docs/config-personals.md
+++ b/docs/config-personals.md
@@ -1,0 +1,42 @@
+# `config/personals.py` — your details
+
+The answers that go into the "about you" fields of an application. Open
+`config/personals.py` and fill these in, or use the **Profile** tab of the control panel.
+
+## Name and contact
+
+| Setting | What it is |
+|---|---|
+| `first_name` | Your legal first name, e.g. `"Sai"` |
+| `middle_name` | Middle name, or `""` if you do not have one |
+| `last_name` | Legal last name |
+| `phone_number` | Ten digits in quotes, e.g. `"9876543210"`. Required, and it must be valid |
+
+## Location
+
+| Setting | What it is |
+|---|---|
+| `current_city` | e.g. `"Austin"`. **If left empty as `""`, the tool answers with the city given in the job posting** — which is usually what you want for "what is your current location?" questions |
+| `street` | Street address. Uncommon, but some applications require it |
+| `state` | e.g. `"Texas"` |
+| `zipcode` | Postal code |
+| `country` | e.g. `"United States"` |
+
+## US Equal Opportunity questions
+
+Each of these can be left as `""` to leave the question unanswered — but note that some
+companies make them compulsory.
+
+| Setting | Valid values |
+|---|---|
+| `ethnicity` | `"Decline"`, `"Hispanic/Latino"`, `"American Indian or Alaska Native"`, `"Asian"`, `"Black or African American"`, `"Native Hawaiian or Other Pacific Islander"`, `"White"`, `"Other"` |
+| `gender` | `"Male"`, `"Female"`, `"Other"`, `"Decline"` or `""` |
+| `disability_status` | `"Yes"`, `"No"`, `"Decline"` |
+| `veteran_status` | `"Yes"`, `"No"`, `"Decline"` |
+
+Answers are case-sensitive and must be one of the listed options. Free-text settings (name,
+address) have no restriction other than the quotes.
+
+---
+
+[← Back to docs index](README.md) · [Configuration overview](configuration.md)

--- a/docs/config-questions.md
+++ b/docs/config-questions.md
@@ -1,0 +1,89 @@
+# `config/questions.py` — Easy Apply answers
+
+What the tool should say when an application asks you something. Open
+`config/questions.py`, or use the **Profile** and **Run settings** tabs of the control panel.
+
+## Resume
+
+| Setting | What it is |
+|---|---|
+| `default_resume_path` | Relative path to the resume to upload, e.g. `"all resumes/default/resume.pdf"`. **Optional** — if the file is not found, the tool keeps using the resume you last uploaded to LinkedIn |
+
+## Experience and profile
+
+| Setting | What it is |
+|---|---|
+| `years_of_experience` | A number in quotes, e.g. `"6"`. This is what gets typed into "how many years of experience do you have" questions. It is **not** the same as `current_experience` in [`config/search.py`](config-search.md), which decides whether a job is skipped |
+| `website` | Portfolio URL, or `""` to leave the question unanswered |
+| `linkedIn` | Your LinkedIn profile URL |
+| `linkedin_headline` | Your headline, e.g. `"Full Stack Developer with Masters in Computer Science and 4+ years of experience"`, or `""` |
+| `linkedin_summary` | Your summary. Use `\n` for line breaks in a `"..."` string, or use `"""..."""` and write it across lines |
+| `cover_letter` | Your cover letter. Same formatting rules as the summary |
+| `user_information_all` | Free-form facts about you that the **AI** may use when drafting answers — name, years of experience, key skills, location, work authorization, anything an answer might need. Only used when AI is on (see [secrets](config-secrets.md)) |
+| `recent_employer` | Name of your most recent employer, e.g. `"Not Applicable"` |
+| `confidence_level` | `"1"` to `"10"` in quotes. Used for "on a scale of 1-10, how much experience do you have..." questions |
+
+Leaving any of these as `""` means the question is left unanswered. Some companies make
+them compulsory.
+
+## Work authorization
+
+These are **three different questions**, and someone on a valid work visa answers them
+differently. The tool matches them in this order — sponsorship, then authorization, then
+citizenship — because "sponsor a new U.S. work visa or work authorization" is a
+sponsorship question, not an authorization one.
+
+| Setting | The question it answers | Valid values |
+|---|---|---|
+| `require_visa` | "Will you now or in the future require sponsorship, or a new/transferred visa?" | `"Yes"` or `"No"` |
+| `legally_authorized` | "Are you legally authorized to work in this country?" — i.e. do you **already** have permission (citizen, permanent resident, or a valid work visa such as H-1B or OPT) | `"Yes"` or `"No"` |
+| `us_citizenship` | "What is your citizenship status?" | `"U.S. Citizen/Permanent Resident"`, `"Non-citizen allowed to work for any employer"`, `"Non-citizen allowed to work for current employer"`, `"Non-citizen seeking work authorization"`, `"Canadian Citizen/Permanent Resident"`, `"Other"`, or `""` to leave it unanswered |
+
+> **`legally_authorized` is not the opposite of `require_visa`.** Someone on a valid work
+> visa answers **`"Yes"` to both**: they are authorized to work today, and they will need a
+> transfer or a new petition later.
+
+`legally_authorized` is only settable by editing `config/questions.py` — it has no field in
+the control panel. It defaults to `"Yes"`.
+
+`require_visa = "Yes"` is also the switch that activates the sponsorship filters in
+[`config/search.py`](config-search.md#visa-sponsorship-filtering). With `require_visa = "No"`
+those settings do nothing at all.
+
+## Salary and notice period
+
+| Setting | What it is |
+|---|---|
+| `desired_salary` | Numbers only, no quotes, e.g. `1200000`. Some companies only accept digits |
+| `current_ctc` | Your current salary, numbers only, no quotes |
+| `notice_period` | Days, no quotes, e.g. `30` |
+
+The tool reshapes these to fit the question it is asked:
+
+- If a salary question contains the word **"lakhs"**, a `.` is inserted before the last five
+  digits — `2400000` is answered as `"24.00"`, `850000` as `"8.50"`.
+- If a salary question asks **per month**, the value is divided by 12 — `2400000` is
+  answered as `"200000"`, `850000` as `"70833"`.
+- If a notice-period question contains **"month"** or **"week"**, the value is divided by 30
+  or 7 respectively — `notice_period = 66` is answered as `"66"`, or `"2"` in months, or
+  `"9"` in weeks.
+
+## Manual-input and answer settings
+
+| Setting | Default | What it does |
+|---|---|---|
+| `pause_before_submit` | `True` | Pause on the final screen of every application so you can check it before it is sent. The dialog offers **Submit Application**, **Discard Application**, or **Disable Pause** (which turns pausing off for the rest of this run only). **Treated as `False` when `run_in_background = True`** |
+| `pause_at_failed_question` | `True` | Pause and wait for you when the tool cannot confidently answer a question. **If set to `False` it answers randomly.** Also treated as `False` when `run_in_background = True` |
+| `overwrite_previous_answers` | `False` | The tool remembers the answer it gave to a question and reuses it. Set to `True` to overwrite a saved answer with the current config value |
+
+For a dry run that fills everything in and stops without submitting, see
+[`stop_before_submit`](config-settings.md#dry-runs-stop_before_submit).
+
+## Not yet implemented
+
+`currency` (the currency tag appended to salary answers for employers that accept text
+input) is commented out in the file and marked *In development*.
+
+---
+
+[← Back to docs index](README.md) · [Configuration overview](configuration.md)

--- a/docs/config-search.md
+++ b/docs/config-search.md
@@ -1,0 +1,94 @@
+# `config/search.py` — what to search for, and what to skip
+
+These settings decide **which jobs the tool applies to**. Open `config/search.py`, or use
+the **Search** and **Filters** tabs of the control panel.
+
+## Search terms
+
+| Setting | What it is |
+|---|---|
+| `search_terms` | A list of the phrases to search LinkedIn for, e.g. `["Software Engineer", "Python Developer"]` |
+| `search_location` | Goes into the "City, state, or zip code" box. `""` leaves it unfilled. Examples: `"United States"`, `"Chicago, Illinois, United States"`, `"90001, Los Angeles, California, United States"`, `"Bengaluru, Karnataka, India"` |
+| `switch_number` | How many applications to make on one search term before moving to the next. Any number greater than 0, no quotes |
+| `randomize_search_order` | `True` or `False`. Shuffles the order of `search_terms` |
+
+## LinkedIn job filters
+
+These map one-to-one onto LinkedIn's own filter controls. Leave a filter empty to not
+select it — `""` for single-choice filters, `[]` for list filters. `True`/`False` filters
+cannot be left empty.
+
+| Setting | Kind | Valid values |
+|---|---|---|
+| `sort_by` | single | `"Most recent"`, `"Most relevant"`, or `""` |
+| `date_posted` | single | `"Any time"`, `"Past month"`, `"Past week"`, `"Past 24 hours"`, or `""` |
+| `salary` | single | `"$40,000+"` through `"$200,000+"` in $20,000 steps, or `""` |
+| `easy_apply_only` | bool | `True` or `False` |
+| `experience_level` | multiple | `"Internship"`, `"Entry level"`, `"Associate"`, `"Mid-Senior level"`, `"Director"`, `"Executive"` |
+| `job_type` | multiple | `"Full-time"`, `"Part-time"`, `"Contract"`, `"Temporary"`, `"Volunteer"`, `"Internship"`, `"Other"` |
+| `on_site` | multiple | `"On-site"`, `"Remote"`, `"Hybrid"` |
+| `companies` | dynamic multiple | Company names, matched exactly including capitals, e.g. `["Google", "JPMorgan Chase & Co."]` |
+| `location` | dynamic multiple | |
+| `industry` | dynamic multiple | |
+| `job_function` | dynamic multiple | |
+| `job_titles` | dynamic multiple | |
+| `benefits` | dynamic multiple | |
+| `commitments` | dynamic multiple | |
+| `under_10_applicants` | bool | `True` or `False` |
+| `in_your_network` | bool | `True` or `False` |
+| `fair_chance_employer` | bool | `True` or `False` |
+
+A **multiple** select takes only values from the listed options. A **dynamic multiple**
+select takes anything — the entries do not have to match a fixed list.
+
+| Setting | Default | What it does |
+|---|---|---|
+| `pause_after_filters` | `True` | Pause once the filters are applied so you can adjust the search and results by hand before the tool starts applying |
+
+## Skipping irrelevant jobs
+
+| Setting | What it does |
+|---|---|
+| `about_company_bad_words` | Skip a company if any of these words appear in its **About company** section. Example: `["Staffing", "Recruiting"]` |
+| `about_company_good_words` | Exceptions to the list above — apply anyway if the About company section contains one of these. Example: `["Robert Half", "Dice"]` |
+| `bad_words` | Skip a job if any of these words or phrases appear in its **job description**. Case-insensitive, matched as whole words/phrases. Example: `["US Citizen", "No C2C", "PHP", "polygraph", "Security Clearance"]` |
+| `security_clearance` | `False` means "I do not hold a clearance", and jobs mentioning clearance or polygraph are skipped. Matched as whole words, so "clearance sale" and "secretary" do not trigger it |
+| `did_masters` | `True` means you have a Master's degree. Jobs whose description contains the word "master" are then allowed up to `current_experience + 2` years of required experience |
+| `current_experience` | Skip jobs requiring more years than this. Set to `-1` to apply regardless of required experience. This is separate from `years_of_experience` in [`config/questions.py`](config-questions.md), which is only what gets typed into the form |
+
+## Visa sponsorship filtering
+
+Four settings, and they only matter to people who need sponsorship.
+
+> **All four are inert unless [`require_visa = "Yes"`](config-questions.md#work-authorization)
+> in `config/questions.py`.** If you do not need sponsorship, they cost you nothing and
+> change nothing.
+
+| Setting | Default | What it does |
+|---|---|---|
+| `skip_non_sponsoring_jobs` | `False` | Skip a job when its description says sponsorship is **not** available. A description that says nothing about sponsorship is still applied to |
+| `sponsorship_offered_phrases` | a starter list | Phrases meaning "we DO sponsor". Checked **first**, and an offer always wins. Real postings say both — "we do not require you to have sponsorship... we will sponsor H-1B transfers" is an offer, not a refusal |
+| `sponsorship_unavailable_phrases` | a starter list | Phrases meaning "we do NOT sponsor". Matched as **whole phrases, never substrings**, so "sponsorship of our annual conference" and "sponsored content" are safe |
+| `skip_jobs_without_sponsorship` | `False` | **Strict mode.** Also skip jobs whose description says nothing either way. Only does anything when `skip_non_sponsoring_jobs` is also `True` |
+
+Both phrase lists are ordinary lists you can edit and extend. Matching is case-insensitive.
+
+### About strict mode
+
+`skip_jobs_without_sponsorship = True` means "apply only where sponsorship is affirmatively
+offered". **Most postings never mention sponsorship at all, so this skips a LOT of jobs,
+including many employers who would in fact have sponsored you.** Silence is not a refusal.
+Recall is worst for exactly the seed and Series-A companies most likely to be silent yet
+sponsor, which is why it is off by default.
+
+Why anyone turns it on: LinkedIn caps Easy Apply at roughly 25 applications a day, so your
+applications are a rationed daily resource. If your runs end by hitting that daily limit, a
+slot spent on a silent posting is a slot denied to one that says "we sponsor". **If your
+runs never hit the cap, leave this off** — every skip is then pure loss.
+
+Only the text of the posting itself is read. Whether the employer has ever sponsored anyone
+before is deliberately not consulted; absence from that kind of data is not evidence.
+
+---
+
+[← Back to docs index](README.md) · [Configuration overview](configuration.md)

--- a/docs/config-secrets.md
+++ b/docs/config-secrets.md
@@ -1,0 +1,44 @@
+# `config/secrets.py` — login and AI
+
+Your LinkedIn credentials and the optional AI setup. Also available in the **Account** tab
+of the control panel.
+
+## LinkedIn login (optional)
+
+| Setting | What it is |
+|---|---|
+| `username` | Your LinkedIn username/email |
+| `password` | Your LinkedIn password |
+
+**Both are optional.** If you leave them at their defaults, the tool logs in using the
+browser's saved profile, or asks you to log in manually in the Chrome window it opens.
+
+Nothing here leaves your computer. `config/secrets.py` and `user_config.json` stay on disk.
+
+## AI setup (optional)
+
+AI is **off by default**. When it is on, it helps answer free-text application questions and
+can read the required skills out of a job description. It needs either a paid API key or a
+local model server, which is why it stays off.
+
+The AI layer is provider-agnostic — it is built on **LangChain + LangGraph**, so one set of
+options covers every provider.
+
+| Setting | What it is |
+|---|---|
+| `use_AI` | Master switch. `True` or `False` |
+| `ai_provider` | `"openai"`, `"gemini"`, or `"deepseek"`. Use `"openai"` for OpenAI **or any OpenAI-compatible server**, including local ones like [Ollama](https://ollama.com/), [LM Studio](https://lmstudio.ai/) and vLLM. `"deepseek"` also behaves like `"openai"`. `"gemini"` uses your Google API key and ignores `llm_api_url` |
+| `llm_model` | The model name your provider offers. OpenAI: `"gpt-4o-mini"`, `"gpt-4o"`, `"gpt-5-mini"`. Local: `"llama-3.2-3b-instruct"`, `"qwen2.5:latest"`. Gemini: `"gemini-2.5-flash"`, `"gemini-2.5-pro"` |
+| `llm_api_key` | Your provider's API key. For local servers any placeholder works — leave it as `"not-needed"` |
+| `llm_api_url` | Base URL of the server. Used by the `"openai"` provider family only. OpenAI: `"https://api.openai.com/v1/"`. LM Studio: `"http://localhost:1234/v1/"`. Ollama: `"http://localhost:11434/v1/"`. DeepSeek: `"https://api.deepseek.com/v1"` |
+| `llm_temperature` | Sampling temperature. Leave as `None` to use the model's own default — **some newer models only allow their default**. Set a number like `0` or `0.3` to override |
+
+What the AI actually uses to answer questions comes from `user_information_all` in
+[`config/questions.py`](config-questions.md#experience-and-profile).
+
+To be told when an AI API connection fails, set `showAiErrorAlerts = True` in
+[`config/settings.py`](config-settings.md).
+
+---
+
+[← Back to docs index](README.md) · [Configuration overview](configuration.md)

--- a/docs/config-settings.md
+++ b/docs/config-settings.md
@@ -1,0 +1,73 @@
+# `config/settings.py` — how the bot runs
+
+Behaviour of the tool itself, rather than what it says in an application. Mostly the
+**Run settings** tab of the control panel.
+
+## LinkedIn behaviour
+
+| Setting | Default | What it does |
+|---|---|---|
+| `close_tabs` | `False` | Whether to close the tabs opened for external (non-Easy-Apply) applications. **If you set this to `False`, close all tabs before closing the browser.** |
+| `follow_companies` | `False` | Follow a company when submitting an Easy Apply application to it |
+
+## Continuous running (beta)
+
+| Setting | Default | What it does |
+|---|---|---|
+| `run_non_stop` | `False` | Keep running until you stop it. **Treated as `False` when `run_in_background = True`** |
+| `alternate_sortby` | `True` | Alternate the "sort by" filter between runs |
+| `cycle_date_posted` | `True` | Cycle through the "date posted" filter between runs |
+| `stop_date_cycle_at_24hr` | `True` | Stop that cycle at "Past 24 hours" rather than going wider |
+
+## Files and logs
+
+| Setting | What it is |
+|---|---|
+| `file_name` | Where the applied-jobs history CSV is written, e.g. `"all excels/all_applied_applications_history.csv"`. Everything after the last `/` is the filename |
+| `failed_file_name` | Same, for failed applications |
+| `logs_folder_path` | Where run logs go, e.g. `"logs/"` |
+| `log_level` | How much detail is written to `logs/log.txt` and printed while the tool runs: `"DEBUG"` for everything, `"INFO"` for the normal running commentary, `"WARNING"` for only what went wrong, `"ERROR"` for only crashes. Case-insensitive; anything unrecognised falls back to `"INFO"` |
+
+## Run behaviour
+
+| Setting | Default | What it does |
+|---|---|---|
+| `click_gap` | `1` | Maximum seconds to wait between clicks. Non-negative whole numbers only |
+| `run_in_background` | `False` | Hide the Chrome window. May reduce performance. **Turning this on forces `pause_before_submit`, `pause_at_failed_question` and `run_non_stop` to `False`** — the safety pauses cannot work with no window to look at |
+| `disable_extensions` | `False` | Disable browser extensions. Better for performance |
+| `safe_mode` | `True` | Open Chrome in a clean **guest profile**. Turn this on if Chrome takes too long to open, or if you have several browser profiles |
+| `smooth_scroll` | `False` | Smooth rather than instantaneous scrolling. Can reduce performance |
+| `keep_screen_awake` | `True` | Keep the screen active and stop the machine sleeping. Temporarily deactivates while a dialog box is up (pause before submit, help needed on a question). The alternative is to set your OS sleep settings to Never |
+| `auto_manage_driver` | `True` | Download and match the right Chrome driver automatically. If `False`, install a matching ChromeDriver yourself — see [install step 5](install.md#manual-install) |
+| `showAiErrorAlerts` | `False` | Alert on errors from the AI API connection |
+
+## Dry runs: `stop_before_submit`
+
+| Setting | Default | What it does |
+|---|---|---|
+| `stop_before_submit` | `False` | Fill in **every** application and stop at the Review step **without submitting** |
+
+Useful for testing the tool, or for checking what it would answer before you trust it with
+a real application. Each application is filled in completely, reaches the Review screen,
+and is then discarded.
+
+Two things worth knowing:
+
+- A `stop_before_submit` stop is **not** counted as a failure. It is counted as a skip, so a
+  clean dry run reads as skipped rather than as an all-failed run.
+- It takes priority over `pause_before_submit` — the application is discarded before the
+  confirmation dialog would appear.
+
+`stop_before_submit` is only settable by editing `config/settings.py`; it has no field in
+the control panel.
+
+## In development
+
+| Setting | Status |
+|---|---|
+| `generated_resume_path` | Folder for generated resumes. Part of the **experimental, in-development** resume generator |
+| `connect_hr`, `connect_request_message` | Commented out in the file. Would send connection requests to recruiters with an optional personalised message (LinkedIn allows only 10 personalised invitations a month without Premium) |
+
+---
+
+[← Back to docs index](README.md) · [Configuration overview](configuration.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,55 @@
+# Configuration
+
+All configuration lives in the `config/` folder as plain Python files. There are two ways
+to change it, and they work together:
+
+- **The control panel** (`python app.py`, or the `start.*` launcher) — a local web page
+  with the common settings laid out in tabs: **Account, Profile, Search, Filters, Run
+  settings**. What you save there is written to `user_config.json` at the project root.
+- **Editing `config/*.py` directly** — the classic route, and the only route for the
+  handful of settings the control panel does not expose.
+
+`user_config.json` is applied *over* the defaults in `config/*.py`, and only for names that
+already exist there — so the panel can never introduce a setting the code does not know
+about. If `user_config.json` does not exist, everything comes from the `.py` files and the
+tool behaves exactly as it always has. Nothing is ever uploaded anywhere.
+
+## Do it in this order
+
+| Step | File | What goes in it |
+|---|---|---|
+| 1 | [`config/personals.py`](config-personals.md) | Your name, phone, address, and the equal-opportunity answers |
+| 2 | [`config/questions.py`](config-questions.md) | Answers to Easy Apply questions: experience, work authorization, salary, notice period, resume path |
+| 3 | [`config/search.py`](config-search.md) | What to search for, which filters to apply, and which jobs to skip |
+| 4 | [`config/secrets.py`](config-secrets.md) | LinkedIn login (optional) and the optional AI setup |
+| 5 | [`config/settings.py`](config-settings.md) | How the bot itself runs: click gap, background mode, screen awake, driver management |
+
+Then run `runAiBot.py` and watch it work. Or run `app.py` for the control panel, which also
+shows your Applied Jobs history.
+
+## Rules that apply to every config file
+
+- Values are **case-sensitive**. `True` and `False` must be capitalised exactly like that.
+- Strings need quotes: `"like this"`. Numbers do not: `desired_salary = 120000`.
+- A **multiple select** setting takes a list: `["answer1", "answer2"]`. Leave it as `[]` to
+  select nothing.
+- A **dynamic multiple select** takes a list too, but the entries do not have to match a
+  fixed set of options.
+- A single-select setting takes one string, or `""` to leave the question unanswered.
+  Beware: some companies make a question compulsory, and an unanswered compulsory question
+  will make the application fail or pause.
+- Invalid values raise a validation error on startup rather than failing halfway through a
+  run. See `modules/validator.py`.
+
+## Not everything is in the control panel
+
+These are set by editing the `.py` file, and have no control-panel field:
+
+| Setting | File | Page |
+|---|---|---|
+| `stop_before_submit` | `config/settings.py` | [Settings](config-settings.md#dry-runs-stop_before_submit) |
+| `legally_authorized` | `config/questions.py` | [Questions](config-questions.md#work-authorization) |
+
+---
+
+[← Back to docs index](README.md)

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,61 @@
+# Installation
+
+There are two ways to set this up. Both need the same two things installed first:
+**Python** and **Google Chrome**.
+
+- **Easy start (recommended)** — a double-click launcher that does the rest for you.
+  See [Quick start in the README](../README.md#-quick-start).
+- **Manual install** — the classic route, described below. Use it if you want to run
+  `runAiBot.py` yourself, or if the launcher does not work on your system.
+
+[![Auto Job Applier setup tutorial video](https://github.com/user-attachments/assets/9e876187-ed3e-4fbf-bd87-4acc145880a2)](https://youtu.be/f9rdz74e1lM?si=4fRBcte0nuvr6tEH)
+
+Click the image above to watch the setup and configuration tutorial, or use this link:
+https://youtu.be/f9rdz74e1lM (recommended to watch at 2x speed).
+
+## Manual install
+
+1. **Install [Python 3.10](https://www.python.org/) or above.** Download it from
+   https://www.python.org/downloads/, or on Windows search for "Python" in the Microsoft
+   Store. **Make sure Python is added to Path in your System Environment Variables.**
+
+2. **Get the project.** Clone the repo or download it as a ZIP:
+   https://github.com/GodsScion/Auto_job_applier_linkedIn
+
+3. **Install the Python packages.** Open a console/terminal in the project folder and run
+   the command below. It uses [pip](https://pip.pypa.io/en/stable) to install everything
+   listed in `requirements.txt`.
+
+   ```
+   pip install -r requirements.txt
+   ```
+
+4. **Install [Google Chrome](https://www.google.com/chrome)** in its default location.
+   Download the installer from https://www.google.com/chrome.
+
+5. **Chrome Driver is taken care of for you.** `auto_manage_driver = True` (the default in
+   `config/settings.py`) downloads the matching driver automatically. If you would rather
+   manage it yourself, set it to `False` and place the matching
+   [Chrome Driver](https://googlechromelabs.github.io/chrome-for-testing/) where Chrome is
+   installed.
+
+6. **Configure the tool** — see [Configuration](configuration.md).
+
+7. **Run it.**
+
+   ```
+   python runAiBot.py     # the bot
+   python app.py          # the local control panel (settings, run controls, applied-jobs history)
+   ```
+
+   `app.py` prints the address to open, e.g. `http://127.0.0.1:5000`, or another port if
+   5000 is busy (on macOS, port 5000 is often taken by AirPlay Receiver).
+
+## Need help?
+
+If you have questions or need help setting it up, or just want to talk, join the Discord
+server: https://discord.gg/fFp7uUzWCY — see also [Support](support.md).
+
+---
+
+[← Back to docs index](README.md)

--- a/docs/legal.md
+++ b/docs/legal.md
@@ -1,0 +1,52 @@
+# Disclaimer, Terms and License
+
+## Disclaimer
+
+**This tool runs on your own computer and acts through your own accounts. It is provided
+free and open source, with no warranty of any kind. You are responsible for how you use it,
+including making sure your use complies with the terms of any website or service you use it
+with. The authors and contributors accept no liability for how it is used.**
+
+## Terms and Conditions
+
+Please consider the following:
+
+- **LinkedIn Policies**: LinkedIn has policies regarding automated activity on its platform.
+  It is your responsibility to review and comply with them before using this tool with your
+  account.
+
+- **No Warranties or Guarantees**: This program is provided as-is, without any warranties or
+  guarantees of any kind. The accuracy, reliability, and effectiveness of the program cannot
+  be guaranteed. Use it at your own risk.
+
+- **Disclaimer of Liability**: The creators and contributors of this program shall not be
+  held responsible or liable for any damages or consequences arising from the direct or
+  indirect use, interaction, or actions performed with this program. This includes but is
+  not limited to any legal issues, loss of data, or other damages incurred.
+
+- **Use at Your Own Risk**: It is important to exercise caution and ensure that your usage,
+  interactions, and actions with this program comply with applicable laws, regulations, and
+  the terms of the services you use it with.
+
+- **Chrome Driver**: This program uses the Chrome Driver to control your browser. Please
+  review and comply with the terms and conditions specified for
+  [Chrome Driver](https://chromedriver.chromium.org/home).
+
+## License
+
+Copyright (c) 2024-2026 Sai Vignesh Golla  <saivigneshgolla@outlook.com>
+
+This project is licensed under the **MIT License**. You are free to use, copy, modify, and
+distribute it — including in commercial and closed-source work — as long as the copyright
+notice and permission notice are preserved. It is provided "as is", without warranty of any
+kind.
+
+Releases before August 2026 were licensed under the AGPL-3.0. See [`NOTICE`](../NOTICE) for
+the relicensing history, and the [`LICENSE`](../LICENSE) file for the full MIT text.
+
+The relicensing record and the acknowledgements for past contributors are in
+[`contributor-consent/contributors.md`](contributor-consent/contributors.md).
+
+---
+
+[← Back to docs index](README.md)

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,0 +1,41 @@
+# Support, community and socials
+
+## Get help
+
+The fastest way to get help setting the tool up, or to talk about it in general, is Discord.
+
+- **Discord server**: https://discord.gg/fFp7uUzWCY
+  (alternate link: https://discord.gg/ykfDjRFB)
+
+## GitHub Discussions
+
+- [All Discussions](https://github.com/GodsScion/Auto_job_applier_linkedIn/discussions)
+- [Announcements](https://github.com/GodsScion/Auto_job_applier_linkedIn/discussions/categories/announcements)
+- [General](https://github.com/GodsScion/Auto_job_applier_linkedIn/discussions/categories/general)
+- [Feature requests or Ideas](https://github.com/GodsScion/Auto_job_applier_linkedIn/discussions/categories/feature-requests-or-ideas)
+- [Polls](https://github.com/GodsScion/Auto_job_applier_linkedIn/discussions/categories/polls)
+- [Community Flex](https://github.com/GodsScion/Auto_job_applier_linkedIn/discussions/categories/community-flex)
+- [Support Q&A](https://github.com/GodsScion/Auto_job_applier_linkedIn/discussions/categories/support-q-a)
+
+## Socials
+
+- **LinkedIn**: https://www.linkedin.com/in/saivigneshgolla/
+- **Email**: saivigneshgolla@outlook.com
+- **X/Twitter**: https://x.com/saivigneshgolla
+- **Discord**: godsscion
+
+## Support the project
+
+This is a free tool built by an independent developer. If it helped you, the two things
+that keep it alive are **sharing it with your peers** and **sponsoring**:
+
+- **GitHub Sponsors**: https://github.com/sponsors/GodsScion
+
+## Releases
+
+Version history and release notes live on the
+[GitHub Releases page](https://github.com/GodsScion/Auto_job_applier_linkedIn/releases).
+
+---
+
+[← Back to docs index](README.md)


### PR DESCRIPTION
`README.md` was 346 lines — the whole project on one page. This splits it into a
`docs/` folder and leaves the README as a shop window.

**README: 346 → 96 lines.** Keeps the demo, what it does, a quick start, a table
of contents into `docs/`, badges, licence and disclaimer links.

```
docs/
  README.md            index / front door
  install.md
  configuration.md     hub, linking the five below
  config-settings.md   config-search.md   config-questions.md
  config-personals.md  config-secrets.md
  legal.md             disclaimer + terms + licence
  support.md           community, socials, sponsoring
```

Configuration is one page per config file, because that matches the editing task —
a single page ran to ~450 lines. `CONTRIBUTING.md` absorbed the Code Guidelines
rather than duplicating them under `docs/`, since that is the file GitHub surfaces
in the PR UI.

**No static-site generator.** GitHub renders `docs/*.md` natively with working
relative links, so mkdocs/Docusaurus/Pages would be machinery to maintain forever
for no gain at this size. The tree is already Pages-shaped if that changes.

### Documents six settings that shipped recently and were never in the README

`stop_before_submit`, `skip_non_sponsoring_jobs`, `sponsorship_offered_phrases`,
`sponsorship_unavailable_phrases`, `skip_jobs_without_sponsorship`,
`legally_authorized` — including the caveats that the sponsorship settings are
inert unless `require_visa = "Yes"`, and that strict mode skips a great many jobs.

### Removes the "Major Updates History" section

Replaced by git tags and GitHub Releases, which now carry the history back to
June 2024. The three May 2024 entries predate this repository's first commit, so
they are preserved inside the `v24.06.19` release notes rather than lost. README,
docs index and support page all link to the releases page.

### Verification

- Link checker over all 15 markdown files: **70 relative links and anchors, 0 broken.**
- Scripted audit of every `^name =` in all five `config/*.py` against the new docs:
  **0 settings undocumented.**
- Test suite untouched and still green.

Also found, not fixed: `<PATREON_LINK>` is an unreplaced placeholder in the footer
of all five `config/*.py` files. Docs point at GitHub Sponsors instead.
