### PR TITLE
Never guess, never wipe: close 4 live defects, add a local-model answer layer, one config source

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,15 +1,3 @@
 # These are supported funding model platforms
 
 github: GodsScion
-patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-polar: # Replace with a single Polar username
-buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
-thanks_dev: # Replace with a single thanks.dev username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ apikeys.py
 user_config.json
 .bot_run.log
 .bot_run.pid
+
+# Cached AI answers to application questions — your own answers, never commit
+.ai_answer_cache.json
+.ai_answer_cache.json.tmp

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,11 @@ user_config.json
 # Cached AI answers to application questions — your own answers, never commit
 .ai_answer_cache.json
 .ai_answer_cache.json.tmp
+
+# Session working docs — handoffs, audits and design notes. These describe the
+# author's own config (phone, city, visa status) and sometimes quote it verbatim.
+# This repo is PUBLIC; they are local notes, never shipped.
+HANDOFF-*.md
+REPORT-*.md
+DESIGN-*.md
+PRODUCT.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,10 +125,11 @@ Once your code is tested, your changes will be merged to the `main` branch in th
         check_string(search_location, "search_location")
     ```
 
-5. If the setting should also appear in the local control panel, add it to
-   `config_schema.py`. Settings left out of the schema are still fully usable by editing the
-   `config/*.py` file, and the [configuration docs](docs/configuration.md) list which ones
-   those are.
+5. Nothing else. `config_schema.py` reads `config/*.py` and builds the control panel's
+   field from your comments: the lines above the assignment become the help text, the
+   trailing comment becomes the legal values (`x = "No"   # "Yes" or "No"` is a dropdown),
+   and the literal picks the control. Add the setting to its `docs/config-*.md` page too —
+   a test fails if the docs and `config/*.py` name different settings.
 
 ## Running the tests
 

--- a/app.py
+++ b/app.py
@@ -35,6 +35,7 @@ from types import ModuleType
 import config_schema
 from config import _overrides
 from modules import updater
+from modules.ai import local
 
 app = Flask(__name__)
 
@@ -428,6 +429,24 @@ def api_save_config():
         return jsonify({"error": f"Could not save settings: {err}"}), 500
 
     return jsonify(_redacted(current))
+
+
+@app.route('/api/ai-suggestion', methods=['GET'])
+def api_ai_suggestion():
+    '''
+    `{state, message}` for the panel's "you could be using AI" banner, or `{}` when
+    there is nothing to say or the user turned the tip off.
+
+    Reads the EFFECTIVE config rather than config.settings: _load_defaults() reloaded
+    those modules with overrides disabled, so their globals are the pristine defaults
+    and would ignore the user's own saved value.
+    '''
+    config = _effective_config()
+    if not config["settings"].get("show_ai_suggestion", True):
+        return jsonify({})
+    found = local.ai_suggestion(bool(config["secrets"].get("use_AI")),
+                                str(config["secrets"].get("llm_api_key") or ""))
+    return jsonify({"state": found[0], "message": found[1]} if found else {})
 
 
 @app.route('/api/run', methods=['POST'])

--- a/app.py
+++ b/app.py
@@ -30,6 +30,7 @@ import signal
 import subprocess
 import threading
 import importlib
+from types import ModuleType
 
 import config_schema
 from config import _overrides
@@ -82,6 +83,9 @@ def _load_defaults() -> dict:
     Import each config module with overrides temporarily disabled, so we read
     the untouched Python defaults regardless of whether user_config.json exists
     right now. Returns {config_module: {key: default_value}}.
+
+    Every module global is captured, not just the ones the panel has a field for,
+    so _freeze_config() below can pin a hand-edited setting the panel never shows.
     '''
     original_loader = _overrides.load_user_config
     _overrides.load_user_config = lambda: {}
@@ -101,13 +105,9 @@ def _load_defaults() -> dict:
         # Reload in case they were already imported (with real overrides) earlier.
         for module in modules.values():
             importlib.reload(module)
-        defaults = {}
-        for field in config_schema.iter_fields():
-            module_name = field["config_module"]
-            key = field["key"]
-            module = modules.get(module_name)
-            defaults.setdefault(module_name, {})[key] = getattr(module, key, None)
-        return defaults
+        return {name: {key: value for key, value in vars(module).items()
+                       if not key.startswith("_") and not isinstance(value, ModuleType)}
+                for name, module in modules.items()}
     finally:
         _overrides.load_user_config = original_loader
 
@@ -122,24 +122,22 @@ def _effective_config() -> dict:
     '''
     Return {config_module: {key: value}} of the pristine defaults overlaid with
     the CURRENT contents of user_config.json (re-read from disk on every call).
-    Only keys defined in config_schema are included.
     '''
     effective = copy.deepcopy(DEFAULTS)
     user = _overrides.load_user_config()
-    for field in config_schema.iter_fields():
-        module_name = field["config_module"]
-        key = field["key"]
+    for module_name, values in effective.items():
         section = user.get(module_name)
-        if isinstance(section, dict) and key in section:
-            effective[module_name][key] = section[key]
+        if isinstance(section, dict):
+            values.update({key: value for key, value in section.items() if key in values})
     return effective
 
 
-def _coerce(field_type: str, value):
+def _coerce(field: dict, value):
     '''
     Coerce an incoming JSON value into the type declared for the field in the
     schema. Raises ValueError on invalid numbers so the caller can reject them.
     '''
+    field_type = field["type"]
     if field_type in ("text", "password", "textarea", "select"):
         return "" if value is None else str(value)
 
@@ -153,8 +151,11 @@ def _coerce(field_type: str, value):
             if text == "":
                 raise ValueError("expected a number, got an empty value")
             number = float(text)
-        # Keep whole numbers as ints (the config defaults are ints).
-        if isinstance(number, float) and number.is_integer():
+        # Whole-number settings must stay whole: modules/validator.py raises a
+        # TypeError on 1.5 at startup, which is far too late to tell the user.
+        if field.get("step") == 1:
+            if number != int(number):
+                raise ValueError("expected a whole number, e.g. 30")
             return int(number)
         return number
 
@@ -397,9 +398,17 @@ def api_save_config():
             if field["type"] == "password" and value == SECRET_PLACEHOLDER:
                 continue                    # what GET redacted, sent back untouched
             try:
-                coerced.setdefault(section, {})[key] = _coerce(field["type"], value)
+                clean = _coerce(field, value)
             except ValueError as err:
                 return jsonify({"error": f"Invalid value for '{section}.{key}': {err}"}), 400
+            # modules/validator.py re-checks these when the bot starts. Checking here too
+            # means the panel can never save a value that makes the next run refuse to run.
+            rejected = [item for item in (clean if isinstance(clean, list) else [clean])
+                        if item not in field.get("options", [item])]
+            if rejected:
+                return jsonify({"error": f"Invalid value for '{section}.{key}': "
+                                         f"{rejected[0]!r} is not one of {field['options']}"}), 400
+            coerced.setdefault(section, {})[key] = clean
 
     if unknown:
         return jsonify({"error": "Unknown settings rejected", "unknown": unknown}), 400
@@ -515,9 +524,14 @@ def _freeze_config() -> None:
     is what stops the update reverting them to the shipped defaults, because
     config/_overrides.py re-applies the JSON over whatever `git pull` writes.
 
-    ponytail: this pins every schema key to today's value, so a later change to
-    a shipped default stops reaching that user. Acceptable - a hand-edited file
-    was already pinned. Freeze only the keys that differ from HEAD if it bites.
+    It pins EVERY setting in config/*.py, including the ones the panel has no
+    field for: `git stash` parks the user's edits and self_update() deliberately
+    never pops that stash, so anything not pinned here comes back as the shipped
+    default after an update.
+
+    ponytail: this pins every setting to today's value, so a later change to a
+    shipped default stops reaching that user. Acceptable - a hand-edited file was
+    already pinned. Freeze only the keys that differ from HEAD if it bites.
     '''
     current = _overrides.load_user_config()
     for section, values in _effective_config().items():

--- a/app.py
+++ b/app.py
@@ -20,7 +20,6 @@ SECURITY: this app handles LinkedIn credentials, so it binds to 127.0.0.1 only
 '''
 
 from flask import Flask, request, jsonify, render_template
-from flask_cors import CORS
 import csv
 from datetime import datetime
 import os
@@ -37,7 +36,6 @@ from config import _overrides
 from modules import updater
 
 app = Flask(__name__)
-CORS(app)
 
 # Project root is the folder this file lives in.
 ROOT = os.path.dirname(os.path.abspath(__file__))
@@ -46,6 +44,32 @@ LOG_PATH = os.path.join(ROOT, ".bot_run.log")
 PID_PATH = os.path.join(ROOT, ".bot_run.pid")
 
 PATH = 'all excels/'
+
+# What /api/config sends instead of a stored password or API key. A bare CORS(app) used
+# to put a wildcard Access-Control-Allow-Origin on this route, so any page open in the
+# user's browser could read the LinkedIn password off 127.0.0.1 in cleartext. POST treats
+# this exact string as "unchanged", so saving the form can never blank a secret the user
+# was never shown.
+SECRET_PLACEHOLDER = "********"
+
+
+def _redacted(config: dict) -> dict:
+    '''Blank out every stored secret before a config dict leaves the process. Mutates
+    and returns `config`; the caller owns a freshly built dict in both call sites.'''
+    for field in config_schema.iter_fields():
+        section = config.get(field["config_module"])
+        if field["type"] == "password" and isinstance(section, dict) and section.get(field["key"]):
+            section[field["key"]] = SECRET_PLACEHOLDER
+    return config
+
+
+def _write_user_config(data: dict) -> None:
+    '''Save user_config.json readable by its owner only. It holds the LinkedIn password,
+    the AI key, the legal name, phone, street address and EEO answers, and a fresh
+    json.dump lands 0644 - world-readable on any shared or multi-user machine.'''
+    with open(USER_CONFIG_PATH, "w", encoding="utf-8") as file:
+        json.dump(data, file, indent=2, ensure_ascii=False)
+    os.chmod(USER_CONFIG_PATH, 0o600)
 
 
 # ===========================================================================
@@ -339,9 +363,9 @@ def api_get_config():
     '''
     Returns the effective config: pristine defaults overlaid with the current
     user_config.json, grouped by config module (secrets, personals, questions,
-    search, settings).
+    search, settings), with every stored secret replaced by SECRET_PLACEHOLDER.
     '''
-    return jsonify(_effective_config())
+    return jsonify(_redacted(_effective_config()))
 
 
 @app.route('/api/config', methods=['POST'])
@@ -370,6 +394,8 @@ def api_save_config():
             if field is None:
                 unknown.append(f"{section}.{key}")
                 continue
+            if field["type"] == "password" and value == SECRET_PLACEHOLDER:
+                continue                    # what GET redacted, sent back untouched
             try:
                 coerced.setdefault(section, {})[key] = _coerce(field["type"], value)
             except ValueError as err:
@@ -388,12 +414,11 @@ def api_save_config():
         current[section] = target
 
     try:
-        with open(USER_CONFIG_PATH, "w", encoding="utf-8") as file:
-            json.dump(current, file, indent=2, ensure_ascii=False)
+        _write_user_config(current)
     except OSError as err:
         return jsonify({"error": f"Could not save settings: {err}"}), 500
 
-    return jsonify(current)
+    return jsonify(_redacted(current))
 
 
 @app.route('/api/run', methods=['POST'])
@@ -500,8 +525,7 @@ def _freeze_config() -> None:
             current[section] = {}
         for key, value in values.items():
             current[section].setdefault(key, value)
-    with open(USER_CONFIG_PATH, "w", encoding="utf-8") as file:
-        json.dump(current, file, indent=2, ensure_ascii=False)
+    _write_user_config(current)
 
 
 @app.route('/api/update-check', methods=['GET'])

--- a/config/personals.py
+++ b/config/personals.py
@@ -8,8 +8,6 @@ License:    MIT License
             https://opensource.org/license/mit
             
 GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
-
-version:    2024.11.28.16.00
 '''
 
 
@@ -74,7 +72,7 @@ THANK YOU for using my tool 😊! Wishing you the best in your job hunt 🙌🏻
 
 Sharing is caring! If you found this tool helpful, please share it with your peers 🥺. Your support keeps this project alive.
 
-Support my work on <PATREON_LINK>. Together, we can help more job seekers.
+Support my work at https://github.com/sponsors/GodsScion. Together, we can help more job seekers.
 
 As an independent developer, I pour my heart and soul into creating tools like this, driven by the genuine desire to make a positive impact.
 

--- a/config/personals.py
+++ b/config/personals.py
@@ -16,9 +16,11 @@ GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
 
 # >>>>>>>>>>> Easy Apply Questions & Inputs <<<<<<<<<<<
 
-# Your legal name
+# Your legal first name
 first_name = "Sai"                 # Your first name in quotes Eg: "First", "Sai"
+# Your middle name. Leave it empty as "" if you don't have one.
 middle_name = "Vignesh"            # Your name in quotes Eg: "Middle", "Vignesh", ""
+# Your legal last name
 last_name = "Golla"                # Your last name in quotes Eg: "Last", "Golla"
 
 # Phone number (required), make sure it's valid.
@@ -32,20 +34,24 @@ Note: If left empty as "", the bot will fill in location of jobs location.
 
 # Address, not so common question but some job applications make it required!
 street = "123 Main Street"
+# Your state, province or region
 state = "STATE"
+# Your ZIP or postal code
 zipcode = "12345"
+# The country you live in
 country = "Will Let You Know When Established"
 
-## US Equal Opportunity questions
+# >>>>>>>>>>> US Equal Opportunity questions <<<<<<<<<<<
 # What is your ethnicity or race? If left empty as "", tool will not answer the question. However, note that some companies make it compulsory to be answered
-ethnicity = "Decline"              # "Decline", "Hispanic/Latino", "American Indian or Alaska Native", "Asian", "Black or African American", "Native Hawaiian or Other Pacific Islander", "White", "Other"
+ethnicity = "Decline"              # "Decline", "Hispanic/Latino", "American Indian or Alaska Native", "Asian", "Black or African American", "Native Hawaiian or Other Pacific Islander", "White", "Other" or ("" to not select)
 
 # How do you identify yourself? If left empty as "", tool will not answer the question. However, note that some companies make compulsory to be answered
 gender = "Decline"                 # "Male", "Female", "Other", "Decline" or ""
 
-# Are you physically disabled or have a history/record of having a disability? If left empty as "", tool will not answer the question. However, note that some companies make it compulsory to be answered
+# Are you physically disabled or have a history/record of having a disability? "Decline" answers "prefer not to say"; there is no blank option for this one.
 disability_status = "Decline"      # "Yes", "No", "Decline"
 
+# Are you a veteran? "Decline" answers "prefer not to say".
 veteran_status = "Decline"         # "Yes", "No", "Decline"
 ##
 

--- a/config/questions.py
+++ b/config/questions.py
@@ -37,16 +37,15 @@ linkedIn = "https://www.linkedin.com/in/saivigneshgolla/"       # "https://www.l
 # This is NOT `require_visa`, which asks whether you need sponsorship. Someone on a valid work visa answers "Yes" to both.
 legally_authorized = "Yes"         # "Yes" or "No"
 
-# What is the status of your citizenship? # If left empty as "", tool will not answer the question. However, note that some companies make it compulsory to be answered
-# Valid options are: "U.S. Citizen/Permanent Resident", "Non-citizen allowed to work for any employer", "Non-citizen allowed to work for current employer", "Non-citizen seeking work authorization", "Canadian Citizen/Permanent Resident" or "Other"
-us_citizenship = "U.S. Citizen/Permanent Resident"
+# What is the status of your citizenship? Some companies make this one compulsory.
+us_citizenship = "U.S. Citizen/Permanent Resident"      # "U.S. Citizen/Permanent Resident", "Non-citizen allowed to work for any employer", "Non-citizen allowed to work for current employer", "Non-citizen seeking work authorization", "Canadian Citizen/Permanent Resident", "Other" or ("" to not select)
 
 # Are you comfortable commuting to this job's location?
 comfortable_commuting = "Yes"      # "Yes" or "No"
 
 
 
-## SOME ANNOYING QUESTIONS BY COMPANIES 🫠 ##
+# >>>>>>>>>>> Salary, notice period and other common questions 🫠 <<<<<<<<<<<
 
 # What to enter in your desired salary question (American and European), What is your expected CTC (South Asian and others)?, only enter in numbers as some companies only allow numbers,
 desired_salary = 1200000          # 80000, 90000, 100000 or 120000 and so on... Do NOT use quotes
@@ -89,7 +88,7 @@ then it will divide by 30 or 7 and answer respectively. Examples:
 '''
 
 # Your LinkedIn headline in quotes Eg: "Software Engineer @ Google, Masters in Computer Science", "Recent Grad Student @ MIT, Computer Science"
-linkedin_headline = "Full Stack Developer with Masters in Computer Science and 4+ years of experience" # "Headline" or "" to leave this question unanswered
+linkedin_headline = "Full Stack Developer with Masters in Computer Science and 4+ years of experience" # Enter your headline, or leave it empty as "" to skip the question
 
 # Your summary in quotes, use \n to add line breaks if using single quotes "Summary".You can skip \n if using triple quotes """Summary"""
 linkedin_summary = """
@@ -116,17 +115,16 @@ Note: If left empty as "", the tool will not answer the question. However, note 
 ''' 
 
 # Name of your most recent employer
-recent_employer = "Not Applicable" # "", "Lala Company", "Google", "Snowflake", "Databricks"
+recent_employer = "Not Applicable" # Enter the company name. Eg: "Google", "Snowflake", "Not Applicable"
 
 # Example question: "On a scale of 1-10 how much experience do you have building web or mobile applications? 1 being very little or only in school, 10 being that you have built and launched applications to real users"
-confidence_level = "8"             # Any number between "1" to "10" including 1 and 10, put it in quotes ""
+confidence_level = "8"             # A number from 1 to 10, in quotes. Eg: "8"
 ##
 
 
 
 # >>>>>>>>>>> RELATED SETTINGS <<<<<<<<<<<
 
-## Allow Manual Inputs
 # Should the tool pause before every submit application during easy apply to let you check the information?
 pause_before_submit = True         # True or False, Note: True or False are case-sensitive
 '''

--- a/config/questions.py
+++ b/config/questions.py
@@ -10,8 +10,6 @@ License:    MIT License
 GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
 
 Support me: https://github.com/sponsors/GodsScion
-
-version:    26.01.20.5.08
 '''
 
 
@@ -158,7 +156,7 @@ THANK YOU for using my tool 😊! Wishing you the best in your job hunt 🙌🏻
 
 Sharing is caring! If you found this tool helpful, please share it with your peers 🥺. Your support keeps this project alive.
 
-Support my work on <PATREON_LINK>. Together, we can help more job seekers.
+Support my work at https://github.com/sponsors/GodsScion. Together, we can help more job seekers.
 
 As an independent developer, I pour my heart and soul into creating tools like this, driven by the genuine desire to make a positive impact.
 

--- a/config/questions.py
+++ b/config/questions.py
@@ -43,6 +43,9 @@ legally_authorized = "Yes"         # "Yes" or "No"
 # Valid options are: "U.S. Citizen/Permanent Resident", "Non-citizen allowed to work for any employer", "Non-citizen allowed to work for current employer", "Non-citizen seeking work authorization", "Canadian Citizen/Permanent Resident" or "Other"
 us_citizenship = "U.S. Citizen/Permanent Resident"
 
+# Are you comfortable commuting to this job's location?
+comfortable_commuting = "Yes"      # "Yes" or "No"
+
 
 
 ## SOME ANNOYING QUESTIONS BY COMPANIES 🫠 ##

--- a/config/search.py
+++ b/config/search.py
@@ -46,27 +46,44 @@ This is below format: QUESTION = VALID_ANSWER
 
 '''
 
+# How should LinkedIn sort the results?
 sort_by = ""                       # "Most recent", "Most relevant" or ("" to not select) 
+# How recently must a job have been posted?
 date_posted = "Past week"         # "Any time", "Past month", "Past week", "Past 24 hours" or ("" to not select)
-salary = ""                        # "$40,000+", "$60,000+", "$80,000+", "$100,000+", "$120,000+", "$140,000+", "$160,000+", "$180,000+", "$200,000+"
+# Only show jobs paying at least this much.
+salary = ""                        # "$40,000+", "$60,000+", "$80,000+", "$100,000+", "$120,000+", "$140,000+", "$160,000+", "$180,000+", "$200,000+" or ("" to not select)
 
+# Only apply to jobs that use LinkedIn's Easy Apply. Recommended, since the tool cannot fill in an employer's own application site.
 easy_apply_only = True             # True or False, Note: True or False are case-sensitive
 
+# What experience levels are you looking for?
 experience_level = []              # (multiple select) "Internship", "Entry level", "Associate", "Mid-Senior level", "Director", "Executive"
+# What kind of employment are you looking for?
 job_type = []                      # (multiple select) "Full-time", "Part-time", "Contract", "Temporary", "Volunteer", "Internship", "Other"
+# Where do you want to work from?
 on_site = []                       # (multiple select) "On-site", "Remote", "Hybrid"
 
+# Only apply at these companies. Names must match LinkedIn exactly, capitals included.
 companies = []                     # (dynamic multiple select) make sure the name you type in list exactly matches with the company name you're looking for, including capitals. 
                                    # Eg: "7-eleven", "Google","X, the moonshot factory","YouTube","CapitalG","Adometry (acquired by Google)","Meta","Apple","Byte Dance","Netflix", "Snowflake","Mineral.ai","Microsoft","JP Morgan","Barclays","Visa","American Express", "Snap Inc", "JPMorgan Chase & Co.", "Tata Consultancy Services", "Recruiting from Scratch", "Epic", and so on...
+# Only apply to jobs in these locations, as LinkedIn spells them.
 location = []                      # (dynamic multiple select)
+# Only apply to jobs in these industries.
 industry = []                      # (dynamic multiple select)
+# Only apply to jobs in these job functions.
 job_function = []                  # (dynamic multiple select)
+# Only apply to jobs whose title LinkedIn groups under these.
 job_titles = []                    # (dynamic multiple select)
+# Only apply to jobs offering these benefits.
 benefits = []                      # (dynamic multiple select)
+# Only apply to jobs with these commitments, e.g. career growth or work-life balance.
 commitments = []                   # (dynamic multiple select)
 
+# Only apply to jobs with fewer than 10 applicants so far.
 under_10_applicants = False        # True or False, Note: True or False are case-sensitive
+# Only apply where you already have a connection.
 in_your_network = False            # True or False, Note: True or False are case-sensitive
+# Only apply to employers who identify as fair-chance employers.
 fair_chance_employer = False       # True or False, Note: True or False are case-sensitive
 
 
@@ -91,7 +108,6 @@ about_company_good_words = []      # (dynamic multiple search) or leave empty as
 # Avoid applying to these companies if they have these bad words in their 'Job Description' section...  (In development)
 bad_words = ["US Citizen","USA Citizen","No C2C", "No Corp2Corp", ".NET", "Embedded Programming", "PHP", "Ruby", "CNC"]                     # (dynamic multiple search) or leave empty as []. Case Insensitive. Ex: ["word_1", "phrase 1", "word word", "polygraph", "US Citizenship", "Security Clearance"]
 
-# Do you have an active Security Clearance? (True for Yes and False for No)
 # Skip jobs whose description says visa sponsorship is NOT available?
 # ONLY does anything when config/questions.py has require_visa = "Yes". If you don't need
 # sponsorship this setting is completely inert - no cost, no change in behaviour.
@@ -118,6 +134,8 @@ sponsorship_unavailable_phrases = ["will not sponsor", "do not sponsor", "does n
 # spent on a silent posting is a slot denied to one that says "we sponsor". If your runs
 # never hit the cap, leave this off - every skip is then pure loss.
 skip_jobs_without_sponsorship = False   # True or False, Note: True or False are case-sensitive
+
+# Do you have an active Security Clearance? (True for Yes and False for No)
 security_clearance = False         # True or False, Note: True or False are case-sensitive
 
 # Do you have a Masters degree? (True for Yes and False for No). If True, the tool will apply to jobs containing the word 'master' in their job description and if it's experience required <= current_experience + 2 and current_experience is not set as -1. 

--- a/config/search.py
+++ b/config/search.py
@@ -10,8 +10,6 @@ License:    MIT License
 GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
 
 Support me: https://github.com/sponsors/GodsScion
-
-version:    26.01.20.5.08
 '''
 
 
@@ -140,7 +138,7 @@ THANK YOU for using my tool 😊! Wishing you the best in your job hunt 🙌🏻
 
 Sharing is caring! If you found this tool helpful, please share it with your peers 🥺. Your support keeps this project alive.
 
-Support my work on <PATREON_LINK>. Together, we can help more job seekers.
+Support my work at https://github.com/sponsors/GodsScion. Together, we can help more job seekers.
 
 As an independent developer, I pour my heart and soul into creating tools like this, driven by the genuine desire to make a positive impact.
 

--- a/config/secrets.py
+++ b/config/secrets.py
@@ -10,8 +10,6 @@ License:    MIT License
 GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
 
 Support me: https://github.com/sponsors/GodsScion
-
-version:    24.12.3.10.30
 '''
 
 
@@ -75,7 +73,7 @@ THANK YOU for using my tool 😊! Wishing you the best in your job hunt 🙌🏻
 
 Sharing is caring! If you found this tool helpful, please share it with your peers 🥺. Your support keeps this project alive.
 
-Support my work on <PATREON_LINK>. Together, we can help more job seekers.
+Support my work at https://github.com/sponsors/GodsScion. Together, we can help more job seekers.
 
 As an independent developer, I pour my heart and soul into creating tools like this, driven by the genuine desire to make a positive impact.
 

--- a/config/secrets.py
+++ b/config/secrets.py
@@ -16,12 +16,15 @@ Support me: https://github.com/sponsors/GodsScion
 ###################################################### CONFIGURE YOUR TOOLS HERE ######################################################
 
 
-# Login Credentials for LinkedIn (Optional)
+# The email you sign in to LinkedIn with. Leave BOTH of these at the example values to
+# skip the automatic login and sign in by hand in the window the tool opens. They cannot
+# be left blank - a value shorter than 5 characters is rejected at startup.
 username = "username@example.com"       # Enter your username in the quotes
+# Your LinkedIn password. It never leaves this computer.
 password = "example_password"           # Enter your password in the quotes
 
 
-## Artificial Intelligence (optional)
+# >>>>>>>>>>> Artificial Intelligence (optional) <<<<<<<<<<<
 # Master switch. Turn AI on to let the tool draft answers to application questions
 # and pull the required skills out of job descriptions. It needs either a paid API
 # key or a local model server, so it stays off by default.
@@ -57,11 +60,11 @@ llm_api_url = "https://api.openai.com/v1/"
 llm_temperature = None
 
 
-## Local model (modules/ai/local.py) — the fast tiered path for form questions.
-# This is separate from the settings above on purpose: those pick your cloud
-# provider, these point at a small model running on your own machine. Defaults
-# are LM Studio's. Leave them alone unless you moved the server or the model.
+# Address of a small model running on your own machine (modules/ai/local.py, the fast
+# tiered path for form questions). Separate from the settings above on purpose: those
+# pick your cloud provider. The default is LM Studio's; leave it unless you moved it.
 local_llm_api_url = "http://127.0.0.1:1234/v1"
+# Name of that local model, exactly as the local server lists it.
 local_llm_model = "qwen/qwen3.5-4b"
 
 

--- a/config/secrets.py
+++ b/config/secrets.py
@@ -59,6 +59,14 @@ llm_api_url = "https://api.openai.com/v1/"
 llm_temperature = None
 
 
+## Local model (modules/ai/local.py) — the fast tiered path for form questions.
+# This is separate from the settings above on purpose: those pick your cloud
+# provider, these point at a small model running on your own machine. Defaults
+# are LM Studio's. Leave them alone unless you moved the server or the model.
+local_llm_api_url = "http://127.0.0.1:1234/v1"
+local_llm_model = "qwen/qwen3.5-4b"
+
+
 
 
 ############################################################################################################

--- a/config/settings.py
+++ b/config/settings.py
@@ -17,7 +17,7 @@ Support me: https://github.com/sponsors/GodsScion
 
 # >>>>>>>>>>> LinkedIn Settings <<<<<<<<<<<
 
-# Keep the External Application tabs open?
+# Close the tabs opened for applications that continue on the employer's own site?
 close_tabs = False                  # True or False, Note: True or False are case-sensitive
 '''
 Note: RECOMMENDED TO LEAVE IT AS `True`, if you set it `False`, be sure to CLOSE ALL TABS BEFORE CLOSING THE BROWSER!!!
@@ -38,8 +38,11 @@ run_non_stop = False                # True or False, Note: True or False are cas
 '''
 Note: Will be treated as False if `run_in_background = True`
 '''
+# While running non-stop, alternate the "Sort by" filter between runs.
 alternate_sortby = True             # True or False, Note: True or False are case-sensitive
+# While running non-stop, cycle the "Date posted" filter between runs.
 cycle_date_posted = True            # True or False, Note: True or False are case-sensitive
+# Stop cycling "Date posted" once it reaches "Past 24 hours" instead of starting over.
 stop_date_cycle_at_24hr = True      # True or False, Note: True or False are case-sensitive
 
 
@@ -59,7 +62,9 @@ generated_resume_path = "all resumes/" # (In Development)
 
 # Directory and name of the files where history of applied jobs is saved (Sentence after the last "/" will be considered as the file name).
 file_name = "all excels/all_applied_applications_history.csv"
+# Same, for the applications that failed part way through.
 failed_file_name = "all excels/all_failed_applications_history.csv"
+# Folder the run logs are written to.
 logs_folder_path = "logs/"
 
 # How much detail to write to logs/log.txt and print while the tool runs.

--- a/config/settings.py
+++ b/config/settings.py
@@ -10,8 +10,6 @@ License:    MIT License
 GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
 
 Support me: https://github.com/sponsors/GodsScion
-
-version:    26.01.20.5.08
 '''
 
 
@@ -113,7 +111,7 @@ THANK YOU for using my tool 😊! Wishing you the best in your job hunt 🙌🏻
 
 Sharing is caring! If you found this tool helpful, please share it with your peers 🥺. Your support keeps this project alive.
 
-Support my work on <PATREON_LINK>. Together, we can help more job seekers.
+Support my work at https://github.com/sponsors/GodsScion. Together, we can help more job seekers.
 
 As an independent developer, I pour my heart and soul into creating tools like this, driven by the genuine desire to make a positive impact.
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -100,6 +100,10 @@ auto_manage_driver = True          # True or False, Note: True or False are case
 # Do you want to get alerts on errors related to AI API connection?
 showAiErrorAlerts = False            # True or False, Note: True or False are case-sensitive
 
+# Show a one-time tip at startup if you are not using AI, explaining what it answers for
+# you and how to run a model on your own computer for free. Turn this off to never see it.
+show_ai_suggestion = True           # True or False, Note: True or False are case-sensitive
+
 
 
 

--- a/config_schema.py
+++ b/config_schema.py
@@ -4,49 +4,92 @@ License:    MIT License
             https://opensource.org/license/mit
 GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
 
-Describes every user-editable setting that the local control panel (app.py +
-templates/control_panel.html) exposes in the browser.
+The field schema the local control panel (app.py + templates/control_panel.html)
+renders its forms from, DERIVED from config/*.py rather than hand-copied.
 
-The panel NEVER edits the config/*.py files. It reads and writes only
-`user_config.json` at the project root, which the config/*.py modules load and
-apply over their built-in defaults (see config/_overrides.py). This schema is
-the single source of truth the web UI renders forms from.
+config/*.py is the single source of truth. This module parses those files with
+`ast` and turns every top-level literal assignment into a form field:
 
-Each field is a dict:
-    {
-      "section":       tab it appears under in the UI (Account, Profile, ...),
-      "config_module": the config/*.py module the setting lives in. This is ALSO
-                       the key used for it inside user_config.json, so it must
-                       match the module name exactly (secrets, personals,
-                       questions, search, settings),
-      "key":           the variable name in that module,
-      "label":         short human label,
-      "type":          one of text, password, textarea, number, bool, select, list,
-      "help":          plain-language explanation (from the config comments),
-      "options":       list of allowed values (select fields only),
-      "advanced":      (optional) True -> shown under a collapsible "Advanced
-                       options" section so the default view stays simple,
-      "ai":            (optional) True -> the field only matters when "Use AI" is
-                       on, so the UI disables it while AI is turned off,
-      "models_by_provider": (optional) suggestions for the model field, keyed by
-                       AI provider; the UI shows them as a dropdown but still
-                       accepts any typed-in model name,
-    }
+  * the comment lines directly ABOVE an assignment - plus a triple-quoted note
+    right below it - become the field's help text,
+  * the trailing comment lists the legal values, so
+    `require_visa = "No"   # "Yes" or "No"` becomes a dropdown,
+  * the literal's type picks the control: bool -> checkbox, int -> number,
+    list -> comma-separated, a string with line breaks -> textarea,
+  * `# >>>>> Something <<<<<` headers group the settings inside a file.
+
+Nothing about a setting is written down twice, so nothing can drift out of sync.
+The only things kept here are the ones that exist ONLY in the browser and have
+no home in a config file: which tab a setting belongs to, whether it hides under
+"Advanced options", and whether it is an AI-only field.
+
+The panel NEVER edits config/*.py. It reads and writes only `user_config.json`,
+which those modules load over their defaults (see config/_overrides.py).
+
+Each derived field is a dict:
+    {"section", "config_module", "key", "label", "type", "help",
+     "options"?, "step"?, "advanced"?, "ai"?, "models_by_provider"?}
 
 Field types:
-    text      - single line of text
-    password  - single line, masked in the browser (with a show/hide toggle)
-    textarea  - multi-line text
-    number    - stored as a number (int/float), not quoted
-    bool      - True / False checkbox
-    select    - pick one from "options"
-    list      - comma-separated text in the UI, stored as a JSON list
+    text / password / textarea / number / bool / select / list
 '''
 
+import ast
+import os
+import re
 
-# Suggested model names per provider. These are only suggestions shown in a
-# dropdown; any model name can still be typed in, since providers add and rename
-# models often. Local models (Ollama / LM Studio) use the "openai" provider.
+_CONFIG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config")
+
+# The config files, in the order the docs tell people to fill them in.
+MODULES = ("secrets", "personals", "questions", "search", "settings")
+
+# Tabs, in the order the panel shows them.
+TAB_ORDER = ("Account", "Profile", "Search", "Filters", "Run settings")
+
+# Which tab a file's settings land on, plus the two `>>>>> ... <<<<<` groups and
+# the one setting that belong somewhere other than their file's tab.
+TAB_BY_MODULE = {"secrets": "Account", "personals": "Profile", "questions": "Profile",
+                 "search": "Search", "settings": "Run settings"}
+TAB_BY_GROUP = {("questions", "RELATED SETTINGS"): "Run settings",
+                ("search", "SKIP IRRELEVANT JOBS"): "Filters"}
+TAB_BY_KEY = {"showAiErrorAlerts": "Account"}   # an AI switch that lives in settings.py
+
+# Tucked under the collapsible "Advanced options" block, so the everyday view stays short.
+ADVANCED = {
+    "llm_api_url", "local_llm_api_url", "local_llm_model", "showAiErrorAlerts",
+    "street", "state", "zipcode", "country",
+    "ethnicity", "gender", "disability_status", "veteran_status",
+    "linkedin_headline", "linkedin_summary", "cover_letter", "user_information_all",
+    "recent_employer", "confidence_level", "overwrite_previous_answers",
+    "switch_number", "randomize_search_order", "sort_by", "salary", "companies",
+    "location", "industry", "job_function", "job_titles", "benefits", "commitments",
+    "did_masters", "security_clearance", "under_10_applicants", "in_your_network",
+    "fair_chance_employer", "pause_after_filters",
+    "close_tabs", "follow_companies", "run_non_stop", "alternate_sortby",
+    "cycle_date_posted", "stop_date_cycle_at_24hr", "generated_resume_path",
+    "file_name", "failed_file_name", "logs_folder_path", "log_level", "click_gap",
+    "disable_extensions", "safe_mode", "smooth_scroll", "keep_screen_awake",
+    "auto_manage_driver",
+}
+
+# Only meaningful while "Use AI" is on; the panel greys these out while it is off.
+AI_FIELDS = {"ai_provider", "llm_model", "llm_api_key", "llm_api_url",
+             "local_llm_api_url", "local_llm_model", "user_information_all",
+             "showAiErrorAlerts"}
+
+# Labels that read badly when derived from the variable name.
+LABELS = {"username": "LinkedIn email", "password": "LinkedIn password", "use_AI": "Use AI",
+          "ai_provider": "AI provider", "llm_model": "AI model", "llm_api_key": "AI API key",
+          "llm_api_url": "AI API URL", "local_llm_api_url": "Local AI server URL",
+          "local_llm_model": "Local AI model", "showAiErrorAlerts": "Show AI error alerts",
+          "linkedIn": "LinkedIn profile URL", "linkedin_headline": "LinkedIn headline",
+          "linkedin_summary": "LinkedIn summary", "us_citizenship": "Citizenship status",
+          "require_visa": "Need visa sponsorship?", "current_ctc": "Current salary",
+          "did_masters": "I have a master's degree"}
+
+# Suggested model names per provider. Only suggestions shown in a dropdown; any model
+# name can still be typed in, since providers add and rename models often. Local models
+# (Ollama / LM Studio) use the "openai" provider.
 AI_MODELS = {
     "openai": [
         "gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-mini", "o4-mini",
@@ -60,222 +103,133 @@ AI_MODELS = {
     ],
 }
 
+_GROUP = re.compile(r"#+\s*>{3,}\s*(.*?)\s*<{3,}")      # `# >>>>> Job Search Filters <<<<<`
+_BANNER = re.compile(r"^#*\s*$|>{3}|<{3}|^#{3,}")       # separator lines, not help
+_QUOTED = re.compile(r'"([^"]*)"')
+# A trailing comment listing EXAMPLES is not a list of legal values.
+_EXAMPLE = re.compile(r"\beg:|\be\.g|\bex:|example|and so on|etc\b", re.IGNORECASE)
 
-def _f(section, config_module, key, label, ftype, help,
-       options=None, advanced=False, ai=False, models_by_provider=None):
+
+def _label(key):
+    '''"phone_number" -> "Phone number", "showAiErrorAlerts" -> "Show Ai Error Alerts".'''
+    if key in LABELS:
+        return LABELS[key]
+    text = re.sub(r"(?<=[a-z])(?=[A-Z])", " ", key.replace("_", " "))
+    return text[0].upper() + text[1:]
+
+
+def _help_above(lines, index):
+    '''The comment block directly above 0-based line `index`, as one paragraph.'''
+    block = []
+    index -= 1
+    while index >= 0 and lines[index].startswith("#"):
+        if not _BANNER.search(lines[index]):
+            block.append(lines[index].lstrip("#").strip())
+        index -= 1
+    return " ".join(reversed(block))
+
+
+def _note_below(body, position, assign):
+    '''A triple-quoted note written right under an assignment, e.g. the "in lakhs"
+    worked examples under `desired_salary`. Anything further down the file belongs
+    to the next section, not to this setting.'''
+    following = body[position + 1] if position + 1 < len(body) else None
+    if (isinstance(following, ast.Expr) and isinstance(following.value, ast.Constant)
+            and isinstance(following.value.value, str)
+            and following.lineno - assign.end_lineno <= 2):
+        return " ".join(following.value.value.split())
+    return ""
+
+
+def _options(trailing):
+    '''Legal values from a trailing comment like `# "Yes" or "No"`, blank first.'''
+    if _EXAMPLE.search(trailing):
+        return []
+    found = _QUOTED.findall(trailing)
+    if len(found) < 2:
+        return []
+    if "" in found:
+        found = [""] + [option for option in found if option != ""]
+    return found
+
+
+def _field(module, key, default, help_text, trailing, group):
     field = {
-        "section": section,
-        "config_module": config_module,
+        "section": TAB_BY_KEY.get(key) or TAB_BY_GROUP.get((module, group))
+                   or TAB_BY_MODULE[module],
+        "config_module": module,
         "key": key,
-        "label": label,
-        "type": ftype,
-        "help": help,
+        "label": _label(key),
+        "type": "text",
+        "help": help_text,
     }
-    if options is not None:
+    options = _options(trailing)
+    if isinstance(default, bool):
+        field["type"] = "bool"
+    elif isinstance(default, (int, float)):
+        field["type"] = "number"
+        # Every numeric setting is a whole number today; `step` says so to the browser
+        # and to app.py, which rejects 1.5 the same way modules/validator.py does.
+        field["step"] = 1 if isinstance(default, int) else "any"
+    elif isinstance(default, list):
+        field["type"] = "list"
+    elif "password" in key or key.endswith("api_key"):
+        field["type"] = "password"
+    elif "\n" in default:
+        field["type"] = "textarea"
+    elif options:
+        field["type"] = "select"
+    if options:
         field["options"] = options
-    if advanced:
+    if key in ADVANCED:
         field["advanced"] = True
-    if ai:
+    if key in AI_FIELDS:
         field["ai"] = True
-    if models_by_provider is not None:
-        field["models_by_provider"] = models_by_provider
+    if key == "llm_model":
+        field["models_by_provider"] = AI_MODELS
     return field
 
 
-# ---------------------------------------------------------------------------
-# The schema, grouped into tabs. Each tab is {"section", "fields": [...]}.
-# Within a tab, fields marked advanced=True are tucked into a collapsible
-# "Advanced options" section by the UI so the everyday view stays simple.
-# ---------------------------------------------------------------------------
-SCHEMA = [
-    {
-        "section": "Account",
-        "fields": [
-            _f("Account", "secrets", "username", "LinkedIn email", "text",
-               "The email address you sign in to LinkedIn with. Optional - if left blank the tool tries the browser's saved login, and asks you to log in by hand if that fails."),
-            _f("Account", "secrets", "password", "LinkedIn password", "password",
-               "Your LinkedIn password. Stored only on this computer in user_config.json (never uploaded anywhere). Optional - leave blank to log in manually."),
-            _f("Account", "secrets", "use_AI", "Use AI", "bool",
-               "Master switch for AI help (tailoring answers, resumes and cover letters). Turn this on only if you have a paid API key or a local AI model running. While it's off, all the AI settings below are disabled."),
-            _f("Account", "secrets", "ai_provider", "AI provider", "select",
-               "Which AI service to use. Pick 'openai' for OpenAI or any OpenAI-compatible service (including local ones like Ollama or LM Studio), 'deepseek' for DeepSeek, or 'gemini' for Google Gemini.",
-               options=["openai", "deepseek", "gemini"], ai=True),
-            _f("Account", "secrets", "llm_model", "AI model", "text",
-               "The model to use. Pick a suggestion from the list or type any model name your provider supports.",
-               ai=True, models_by_provider=AI_MODELS),
-            _f("Account", "secrets", "llm_api_key", "AI API key", "password",
-               "Your AI service API key. Use 'not-needed' for local models like Ollama. A wrong key causes errors while AI is on.",
-               ai=True),
-            # --- advanced AI plumbing ---
-            _f("Account", "secrets", "llm_api_url", "AI API URL", "text",
-               "The address of your AI service. Examples: https://api.openai.com/v1/ , http://localhost:1234/v1/ , https://api.deepseek.com . Keep the trailing slash. You may not need this for Gemini.",
-               ai=True, advanced=True),
-            _f("Account", "settings", "showAiErrorAlerts", "Show AI error alerts", "bool",
-               "Pop up an alert if there's a problem connecting to the AI service.",
-               ai=True, advanced=True),
-        ],
-    },
-    {
-        "section": "Profile",
-        "fields": [
-            # --- everyday details ---
-            _f("Profile", "personals", "first_name", "First name", "text",
-               "Your legal first name."),
-            _f("Profile", "personals", "middle_name", "Middle name", "text",
-               "Your middle name. Leave blank if you don't have one."),
-            _f("Profile", "personals", "last_name", "Last name", "text",
-               "Your legal last name."),
-            _f("Profile", "personals", "phone_number", "Phone number", "text",
-               "A valid phone number. Applications often require this."),
-            _f("Profile", "personals", "current_city", "Current city", "text",
-               "The city you live in. If left blank, the tool fills in the job's location instead."),
-            _f("Profile", "questions", "years_of_experience", "Years of experience", "text",
-               "What to answer for 'how many years of experience do you have' questions. A number in text, e.g. 0, 1, 3, 5."),
-            _f("Profile", "questions", "require_visa", "Need visa sponsorship?", "select",
-               "Do you need visa sponsorship now or in the future?",
-               options=["Yes", "No"]),
-            _f("Profile", "questions", "us_citizenship", "Citizenship status", "select",
-               "Your work-authorization / citizenship status for US applications.",
-               options=["U.S. Citizen/Permanent Resident", "Non-citizen allowed to work for any employer", "Non-citizen allowed to work for current employer", "Non-citizen seeking work authorization", "Canadian Citizen/Permanent Resident", "Other"]),
-            _f("Profile", "questions", "desired_salary", "Desired salary", "number",
-               "Your expected salary or CTC as a plain number (no currency symbols or commas), e.g. 100000. Some forms only accept numbers."),
-            _f("Profile", "questions", "current_ctc", "Current salary", "number",
-               "Your current salary or CTC as a plain number, e.g. 80000."),
-            _f("Profile", "questions", "notice_period", "Notice period (days)", "number",
-               "Your notice period in days, e.g. 0, 15, 30. The tool converts to weeks or months if a form asks that way."),
-            _f("Profile", "questions", "linkedIn", "LinkedIn profile URL", "text",
-               "The link to your LinkedIn profile, e.g. https://www.linkedin.com/in/yourname ."),
-            _f("Profile", "questions", "website", "Portfolio website", "text",
-               "Link to your portfolio or personal website. Leave blank to skip this question."),
-            _f("Profile", "questions", "default_resume_path", "Default resume path", "text",
-               "Path to the resume file to upload, relative to the project folder, e.g. all resumes/default/resume.pdf . If the file is missing, the tool keeps your last resume on LinkedIn."),
-            # --- advanced / less-common details ---
-            _f("Profile", "personals", "street", "Street address", "text",
-               "Your street address. Some applications require it.", advanced=True),
-            _f("Profile", "personals", "state", "State / region", "text",
-               "Your state or region.", advanced=True),
-            _f("Profile", "personals", "zipcode", "ZIP / postal code", "text",
-               "Your ZIP or postal code.", advanced=True),
-            _f("Profile", "personals", "country", "Country", "text",
-               "The country you live in.", advanced=True),
-            _f("Profile", "personals", "ethnicity", "Ethnicity / race", "select",
-               "Used for optional US equal-opportunity questions. Choose 'Decline' to prefer not to answer. A blank leaves the question unanswered, but some companies make it required.",
-               options=["", "Decline", "Hispanic/Latino", "American Indian or Alaska Native", "Asian", "Black or African American", "Native Hawaiian or Other Pacific Islander", "White", "Other"], advanced=True),
-            _f("Profile", "personals", "gender", "Gender", "select",
-               "Used for optional equal-opportunity questions. Choose 'Decline' to prefer not to answer, or leave blank to skip (some companies require it).",
-               options=["", "Male", "Female", "Other", "Decline"], advanced=True),
-            _f("Profile", "personals", "disability_status", "Disability status", "select",
-               "Do you have, or have a record of, a disability? Choose 'Decline' to prefer not to answer.",
-               options=["Yes", "No", "Decline"], advanced=True),
-            _f("Profile", "personals", "veteran_status", "Veteran status", "select",
-               "Your veteran status. Choose 'Decline' to prefer not to answer.",
-               options=["Yes", "No", "Decline"], advanced=True),
-            _f("Profile", "questions", "linkedin_headline", "LinkedIn headline", "text",
-               "A short professional headline, e.g. 'Full Stack Developer, MSc Computer Science, 4+ years experience'. Leave blank to skip.", advanced=True),
-            _f("Profile", "questions", "linkedin_summary", "LinkedIn summary", "textarea",
-               "A few sentences about your background and skills. Used to answer 'tell us about yourself' style questions. Leave blank to skip.", advanced=True),
-            _f("Profile", "questions", "cover_letter", "Cover letter", "textarea",
-               "A default cover letter to submit when one is requested. Leave blank to skip.", advanced=True),
-            _f("Profile", "questions", "recent_employer", "Most recent employer", "text",
-               "The name of your most recent employer.", advanced=True),
-            _f("Profile", "questions", "confidence_level", "Confidence level (1-10)", "text",
-               "For 'on a scale of 1-10, how much experience...' questions. Any number from 1 to 10.", advanced=True),
-        ],
-    },
-    {
-        "section": "Search",
-        "fields": [
-            _f("Search", "search", "search_terms", "Search terms", "list",
-               "Job titles to search for, separated by commas, e.g. Software Engineer, Python Developer, Full Stack Developer."),
-            _f("Search", "search", "search_location", "Search location", "text",
-               "Where to look for jobs. Examples: United States, India, 'Chicago, Illinois, United States'. Leave blank to not set a location."),
-            _f("Search", "search", "date_posted", "Date posted", "select",
-               "Only include jobs posted within this window. Leave blank to not filter by date.",
-               options=["", "Any time", "Past month", "Past week", "Past 24 hours"]),
-            _f("Search", "search", "easy_apply_only", "Easy Apply only", "bool",
-               "Only apply to jobs that use LinkedIn's Easy Apply. Recommended on."),
-            _f("Search", "search", "experience_level", "Experience level", "list",
-               "Filter by experience level, comma-separated. Valid values: Internship, Entry level, Associate, Mid-Senior level, Director, Executive. Leave blank for all."),
-            _f("Search", "search", "job_type", "Job type", "list",
-               "Filter by job type, comma-separated. Valid values: Full-time, Part-time, Contract, Temporary, Volunteer, Internship, Other. Leave blank for all."),
-            _f("Search", "search", "on_site", "On-site / Remote", "list",
-               "Filter by work setting, comma-separated. Valid values: On-site, Remote, Hybrid. Leave blank for all."),
-            _f("Search", "search", "current_experience", "Your years of experience", "number",
-               "Your actual years of experience. Jobs asking for more than this are skipped. Set to -1 to ignore required experience and apply to everything."),
-            # --- advanced search options ---
-            _f("Search", "search", "switch_number", "Applications before switching term", "number",
-               "How many applications to submit for one search term before moving on to the next. A number greater than 0.", advanced=True),
-            _f("Search", "search", "randomize_search_order", "Randomize search order", "bool",
-               "Shuffle the order your search terms are used.", advanced=True),
-            _f("Search", "search", "sort_by", "Sort results by", "select",
-               "How LinkedIn should sort results. Leave blank to not change it.",
-               options=["", "Most recent", "Most relevant"], advanced=True),
-            _f("Search", "search", "salary", "Minimum salary", "select",
-               "Only include jobs at or above this salary. Leave blank to not filter by salary.",
-               options=["", "$40,000+", "$60,000+", "$80,000+", "$100,000+", "$120,000+", "$140,000+", "$160,000+", "$180,000+", "$200,000+"], advanced=True),
-            _f("Search", "search", "companies", "Only these companies", "list",
-               "Only apply at these companies, comma-separated. Names must match LinkedIn exactly (including capitals). Leave blank for all companies.", advanced=True),
-            _f("Search", "search", "did_masters", "I have a master's degree", "bool",
-               "If on, jobs mentioning 'master' are still considered when their required experience is within about 2 years of yours.", advanced=True),
-            _f("Search", "search", "security_clearance", "I have a security clearance", "bool",
-               "Whether you hold an active security clearance.", advanced=True),
-            _f("Search", "search", "under_10_applicants", "Under 10 applicants only", "bool",
-               "Only apply to jobs with fewer than 10 applicants so far.", advanced=True),
-            _f("Search", "search", "in_your_network", "In your network only", "bool",
-               "Only apply to jobs at companies where you have a connection.", advanced=True),
-            _f("Search", "search", "fair_chance_employer", "Fair-chance employers only", "bool",
-               "Only apply to employers who identify as fair-chance employers.", advanced=True),
-        ],
-    },
-    {
-        "section": "Filters",
-        "fields": [
-            _f("Filters", "search", "about_company_bad_words", "Skip companies with these words", "list",
-               "Skip a company if any of these words appear in its 'About company' section, comma-separated. Example: Staffing, Recruiting."),
-            _f("Filters", "search", "about_company_good_words", "Keep companies with these words", "list",
-               "Exceptions to the list above: apply anyway if the 'About company' section contains one of these words, comma-separated. Example: Robert Half."),
-            _f("Filters", "search", "bad_words", "Skip jobs with these words", "list",
-               "Skip a job if any of these words or phrases appear in its description, comma-separated and case-insensitive. Example: US Citizen, No C2C, PHP."),
-            _f("Filters", "search", "skip_non_sponsoring_jobs", "Skip jobs that say they won't sponsor a visa", "bool",
-               "Only does anything when 'Do you need visa sponsorship?' is set to Yes. Reads the job description: if it says sponsorship is not available, the job is skipped. A description that says nothing about sponsorship is still applied to."),
-            _f("Filters", "search", "sponsorship_offered_phrases", "Phrases that mean they DO sponsor", "list",
-               "Checked first, and an offer always wins - real postings say both. Example: we will sponsor, H-1B transfer, cap-exempt."),
-            _f("Filters", "search", "sponsorship_unavailable_phrases", "Phrases that mean they do NOT sponsor", "list",
-               "Matched as whole phrases, never substrings, so 'sponsorship of our annual conference' is safe. Example: unable to sponsor, without sponsorship, not eligible for visa sponsorship."),
-            _f("Filters", "search", "skip_jobs_without_sponsorship", "Also skip jobs that say nothing about sponsorship", "bool",
-               "Strict mode. Only does anything when the setting above is on. Applies only where sponsorship is explicitly offered - most postings never mention it either way, so this skips a lot of jobs, including employers who would have sponsored. Worth it only if your runs end on LinkedIn's ~25/day Easy Apply limit, where a slot spent on a silent posting is a slot denied to one that says 'we sponsor'."),
-        ],
-    },
-    {
-        "section": "Run settings",
-        "fields": [
-            _f("Run settings", "settings", "run_in_background", "Run in background", "bool",
-               "Hide the Chrome window while it works. Note: turning this on disables the 'pause before submit' and 'pause on hard questions' safety pauses."),
-            _f("Run settings", "questions", "pause_before_submit", "Pause before submitting", "bool",
-               "Pause on the final screen of each application so you can review it before it's sent. Recommended on. Ignored when 'Run in background' is on."),
-            _f("Run settings", "questions", "pause_at_failed_question", "Pause on hard questions", "bool",
-               "Pause and wait for you when the tool can't confidently answer a question. If off, it answers randomly. Ignored when 'Run in background' is on."),
-            # --- advanced run options ---
-            _f("Run settings", "settings", "auto_manage_driver", "Manage Chrome driver automatically", "bool",
-               "Let the tool download and match the right Chrome driver for you. Recommended on so you don't have to install it yourself.", advanced=True),
-            _f("Run settings", "settings", "safe_mode", "Safe mode", "bool",
-               "Open Chrome in a clean guest profile. Turn on if Chrome is slow to start or you have several browser profiles.", advanced=True),
-            _f("Run settings", "settings", "click_gap", "Pause between clicks (seconds)", "number",
-               "Roughly how many seconds to wait between actions. A whole number, e.g. 0, 1, 2.", advanced=True),
-            _f("Run settings", "settings", "keep_screen_awake", "Keep screen awake", "bool",
-               "Stop your computer from sleeping while the tool runs. Turn off if you'd rather manage sleep in your system settings.", advanced=True),
-            _f("Run settings", "settings", "close_tabs", "Close external application tabs", "bool",
-               "Close tabs opened for external (non-Easy-Apply) applications. If off, remember to close all tabs before closing the browser.", advanced=True),
-            _f("Run settings", "settings", "follow_companies", "Follow companies after applying", "bool",
-               "Automatically follow a company on LinkedIn after applying to it.", advanced=True),
-            _f("Run settings", "settings", "log_level", "Log detail", "select",
-               "How much detail to write to logs/log.txt and show while the tool runs. INFO is the normal running commentary, DEBUG adds everything, WARNING and ERROR show only problems.",
-               options=["DEBUG", "INFO", "WARNING", "ERROR"], advanced=True),
-            _f("Run settings", "questions", "overwrite_previous_answers", "Overwrite saved answers", "bool",
-               "Replace answers you've previously entered on LinkedIn with the ones configured here.", advanced=True),
-        ],
-    },
-]
+def _parse(module):
+    '''Every top-level literal assignment in config/<module>.py, as a field dict.'''
+    with open(os.path.join(_CONFIG_DIR, module + ".py"), encoding="utf-8") as handle:
+        source = handle.read()
+    lines = source.splitlines()
+    body = ast.parse(source).body
+    groups, group = [], ""          # the `>>>>> ... <<<<<` header each line sits under
+    for line in lines:
+        found = _GROUP.match(line.strip())
+        group = found.group(1) if found else group
+        groups.append(group)
+    fields = []
+    for position, node in enumerate(body):
+        if not (isinstance(node, ast.Assign) and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)):
+            continue
+        key = node.targets[0].id
+        try:
+            default = ast.literal_eval(node.value)
+        except ValueError:
+            continue                    # an import or an expression, not a setting
+        if key.startswith("_") or default is None:
+            continue                    # `None` carries no type a form control can render
+        # Bytes, because ast column offsets are UTF-8 offsets and comments carry emoji.
+        end = lines[node.value.end_lineno - 1].encode("utf-8")
+        trailing = end[node.value.end_col_offset:].decode("utf-8").strip()
+        help_text = " ".join(filter(None, [_help_above(lines, node.lineno - 1),
+                                           _note_below(body, position, node)]))
+        fields.append(_field(module, key, default, help_text, trailing,
+                             groups[node.lineno - 1]))
+    return fields
+
+
+def _build():
+    fields = [field for module in MODULES for field in _parse(module)]
+    return [{"section": tab, "fields": [f for f in fields if f["section"] == tab]}
+            for tab in TAB_ORDER]
+
+
+SCHEMA = _build()
 
 
 def iter_fields():

--- a/config_schema.py
+++ b/config_schema.py
@@ -25,13 +25,6 @@ no home in a config file: which tab a setting belongs to, whether it hides under
 
 The panel NEVER edits config/*.py. It reads and writes only `user_config.json`,
 which those modules load over their defaults (see config/_overrides.py).
-
-Each derived field is a dict:
-    {"section", "config_module", "key", "label", "type", "help",
-     "options"?, "step"?, "advanced"?, "ai"?, "models_by_provider"?}
-
-Field types:
-    text / password / textarea / number / bool / select / list
 '''
 
 import ast
@@ -142,7 +135,13 @@ def _note_below(body, position, assign):
 
 
 def _options(trailing):
-    '''Legal values from a trailing comment like `# "Yes" or "No"`, blank first.'''
+    '''Legal values from a trailing comment like `# "Yes" or "No"`, blank first.
+
+    ponytail: two quoted values means a vocabulary unless the comment says "Eg:". A
+    comment that lists examples without saying so would wrongly become a dropdown;
+    tests/test_config_overrides.py pins the awkward ones. Read the comment shape from
+    a marker like `(multiple select)` if writing `Eg:` ever stops being the habit.
+    '''
     if _EXAMPLE.search(trailing):
         return []
     found = _QUOTED.findall(trailing)

--- a/docs/config-personals.md
+++ b/docs/config-personals.md
@@ -29,7 +29,7 @@ companies make them compulsory.
 
 | Setting | Valid values |
 |---|---|
-| `ethnicity` | `"Decline"`, `"Hispanic/Latino"`, `"American Indian or Alaska Native"`, `"Asian"`, `"Black or African American"`, `"Native Hawaiian or Other Pacific Islander"`, `"White"`, `"Other"` |
+| `ethnicity` | `"Decline"`, `"Hispanic/Latino"`, `"American Indian or Alaska Native"`, `"Asian"`, `"Black or African American"`, `"Native Hawaiian or Other Pacific Islander"`, `"White"`, `"Other"` or `""` |
 | `gender` | `"Male"`, `"Female"`, `"Other"`, `"Decline"` or `""` |
 | `disability_status` | `"Yes"`, `"No"`, `"Decline"` |
 | `veteran_status` | `"Yes"`, `"No"`, `"Decline"` |

--- a/docs/config-questions.md
+++ b/docs/config-questions.md
@@ -43,8 +43,8 @@ sponsorship question, not an authorization one.
 > visa answers **`"Yes"` to both**: they are authorized to work today, and they will need a
 > transfer or a new petition later.
 
-`legally_authorized` is only settable by editing `config/questions.py` — it has no field in
-the control panel. It defaults to `"Yes"`.
+`legally_authorized` is in the **Profile** tab, and settable by editing
+`config/questions.py`. It defaults to `"Yes"`.
 
 `require_visa = "Yes"` is also the switch that activates the sponsorship filters in
 [`config/search.py`](config-search.md#visa-sponsorship-filtering). With `require_visa = "No"`
@@ -62,8 +62,8 @@ city typed into a Yes/No box. A Yes/No question that merely mentions a field
 (location, address, name, phone, experience) is no longer answered with that field's
 value; it is either answered from config or left for you.
 
-`comfortable_commuting` is only settable by editing `config/questions.py` — it has no
-field in the control panel. It defaults to `"Yes"`.
+`comfortable_commuting` is in the **Profile** tab, and settable by editing
+`config/questions.py`. It defaults to `"Yes"`.
 
 ## Salary and notice period
 

--- a/docs/config-questions.md
+++ b/docs/config-questions.md
@@ -50,6 +50,21 @@ the control panel. It defaults to `"Yes"`.
 [`config/search.py`](config-search.md#visa-sponsorship-filtering). With `require_visa = "No"`
 those settings do nothing at all.
 
+## Commuting
+
+| Setting | The question it answers | Valid values |
+|---|---|---|
+| `comfortable_commuting` | "Are you comfortable commuting to this job's location?" | `"Yes"` or `"No"` |
+
+That question carries the word "location", so before this setting existed the tool
+answered it with `current_city` from [`config/personals.py`](config-personals.md) — the
+city typed into a Yes/No box. A Yes/No question that merely mentions a field
+(location, address, name, phone, experience) is no longer answered with that field's
+value; it is either answered from config or left for you.
+
+`comfortable_commuting` is only settable by editing `config/questions.py` — it has no
+field in the control panel. It defaults to `"Yes"`.
+
 ## Salary and notice period
 
 | Setting | What it is |

--- a/docs/config-secrets.md
+++ b/docs/config-secrets.md
@@ -10,8 +10,10 @@ of the control panel.
 | `username` | Your LinkedIn username/email |
 | `password` | Your LinkedIn password |
 
-**Both are optional.** If you leave them at their defaults, the tool logs in using the
+**Both are optional.** If you leave them **at their defaults**, the tool logs in using the
 browser's saved profile, or asks you to log in manually in the Chrome window it opens.
+Leave them as they are rather than blanking them: a value shorter than 5 characters is
+rejected when the tool starts.
 
 Nothing here leaves your computer. `config/secrets.py` and `user_config.json` stay on disk.
 
@@ -31,7 +33,18 @@ options covers every provider.
 | `llm_model` | The model name your provider offers. OpenAI: `"gpt-4o-mini"`, `"gpt-4o"`, `"gpt-5-mini"`. Local: `"llama-3.2-3b-instruct"`, `"qwen2.5:latest"`. Gemini: `"gemini-2.5-flash"`, `"gemini-2.5-pro"` |
 | `llm_api_key` | Your provider's API key. For local servers any placeholder works — leave it as `"not-needed"` |
 | `llm_api_url` | Base URL of the server. Used by the `"openai"` provider family only. OpenAI: `"https://api.openai.com/v1/"`. LM Studio: `"http://localhost:1234/v1/"`. Ollama: `"http://localhost:11434/v1/"`. DeepSeek: `"https://api.deepseek.com/v1"` |
-| `llm_temperature` | Sampling temperature. Leave as `None` to use the model's own default — **some newer models only allow their default**. Set a number like `0` or `0.3` to override |
+| `llm_temperature` | Sampling temperature. Leave as `None` to use the model's own default — **some newer models only allow their default**. Set a number like `0` or `0.3` to override. The only setting with no control-panel field, because `None` is not something a form control can say |
+
+## The local model
+
+A second, smaller model running on your own machine answers short form questions faster and
+for free (`modules/ai/local.py`). It is separate from the provider settings above: those
+pick your cloud service, these point at your own. The defaults are [LM Studio](https://lmstudio.ai/)'s.
+
+| Setting | What it is |
+|---|---|
+| `local_llm_api_url` | Address of the local server, e.g. `"http://127.0.0.1:1234/v1"` |
+| `local_llm_model` | The model name, exactly as the local server lists it |
 
 What the AI actually uses to answer questions comes from `user_information_all` in
 [`config/questions.py`](config-questions.md#experience-and-profile).

--- a/docs/config-settings.md
+++ b/docs/config-settings.md
@@ -58,15 +58,15 @@ Two things worth knowing:
 - It takes priority over `pause_before_submit` — the application is discarded before the
   confirmation dialog would appear.
 
-`stop_before_submit` is only settable by editing `config/settings.py`; it has no field in
-the control panel.
+`stop_before_submit` is in the **Run settings** tab, and settable by editing
+`config/settings.py`.
 
 ## In development
 
 | Setting | Status |
 |---|---|
 | `generated_resume_path` | Folder for generated resumes. Part of the **experimental, in-development** resume generator |
-| `connect_hr`, `connect_request_message` | Commented out in the file. Would send connection requests to recruiters with an optional personalised message (LinkedIn allows only 10 personalised invitations a month without Premium) |
+| connect_hr, connect_request_message (commented out, so not settings yet) | Would send connection requests to recruiters with an optional personalised message (LinkedIn allows only 10 personalised invitations a month without Premium) |
 
 ---
 

--- a/docs/config-settings.md
+++ b/docs/config-settings.md
@@ -40,6 +40,7 @@ Behaviour of the tool itself, rather than what it says in an application. Mostly
 | `keep_screen_awake` | `True` | Keep the screen active and stop the machine sleeping. Temporarily deactivates while a dialog box is up (pause before submit, help needed on a question). The alternative is to set your OS sleep settings to Never |
 | `auto_manage_driver` | `True` | Download and match the right Chrome driver automatically. If `False`, install a matching ChromeDriver yourself — see [install step 5](install.md#manual-install) |
 | `showAiErrorAlerts` | `False` | Alert on errors from the AI API connection |
+| `show_ai_suggestion` | `True` | Show a one-time tip at startup when you are not using AI, explaining what it answers for you and how to run a model locally for free. Set to `False` to never see it again |
 
 ## Dry runs: `stop_before_submit`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,8 +6,9 @@ to change it, and they work together:
 - **The control panel** (`python app.py`, or the `start.*` launcher) — a local web page
   with the common settings laid out in tabs: **Account, Profile, Search, Filters, Run
   settings**. What you save there is written to `user_config.json` at the project root.
-- **Editing `config/*.py` directly** — the classic route, and the only route for the
-  handful of settings the control panel does not expose.
+- **Editing `config/*.py` directly** — the classic route, and still the fullest one: the
+  panel builds its own fields by reading these files, so the comments in them are the
+  same help text it shows you.
 
 `user_config.json` is applied *over* the defaults in `config/*.py`, and only for names that
 already exist there — so the panel can never introduce a setting the code does not know
@@ -43,13 +44,14 @@ shows your Applied Jobs history.
 
 ## Not everything is in the control panel
 
-These are set by editing the `.py` file, and have no control-panel field:
+One setting is set by editing the `.py` file and has no control-panel field:
 
-| Setting | File | Page |
+| Setting | File | Why |
 |---|---|---|
-| `stop_before_submit` | `config/settings.py` | [Settings](config-settings.md#dry-runs-stop_before_submit) |
-| `legally_authorized` | `config/questions.py` | [Questions](config-questions.md#work-authorization) |
-| `comfortable_commuting` | `config/questions.py` | [Questions](config-questions.md#commuting) |
+| `llm_temperature` | `config/secrets.py` | Its default is `None`, meaning "leave it to the model". No form control says "unset", and the panel would have to invent a number |
+
+Everything else in `config/*.py` has a field. The panel derives them from these files, so
+adding a setting to a `.py` file is all it takes for one to appear.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,7 @@ These are set by editing the `.py` file, and have no control-panel field:
 |---|---|---|
 | `stop_before_submit` | `config/settings.py` | [Settings](config-settings.md#dry-runs-stop_before_submit) |
 | `legally_authorized` | `config/questions.py` | [Questions](config-questions.md#work-authorization) |
+| `comfortable_commuting` | `config/questions.py` | [Questions](config-questions.md#commuting) |
 
 ---
 

--- a/modules/ai/cache.py
+++ b/modules/ai/cache.py
@@ -11,8 +11,10 @@ job into free work. Plain JSON at the project root, stdlib only.
 
 The file is meant to be HAND-EDITED, which is why keys carry the readable
 question and not just a digest, and why a "no truthful answer" result is stored
-as `null` rather than dropped - the null entries are the worklist of questions
-worth answering yourself in config/questions.py.
+as `null` rather than dropped. Those null entries are the worklist: `record()`
+writes one for every question the bot could not answer, with its control type
+and options, and typing an answer in beside it answers that question on the next
+run with no model call. It is where the user teaches the bot.
 
 It holds the user's own answers, so it is gitignored and written 0600.
 '''
@@ -62,7 +64,10 @@ def _load() -> dict:
 
 def get(question: str, options=None):
     '''Stored answer, or `MISS`. A stored `None` is a real result: asked, no truthful answer.'''
-    return _load().get(key(question, options), MISS)
+    entry = _load().get(key(question, options), MISS)
+    # A question `record()`ed for the user carries its type and options alongside the
+    # answer, so the file shows him WHAT he is answering. Everything else is a bare value.
+    return entry.get("answer") if isinstance(entry, dict) else entry
 
 
 def put(question: str, answer, options=None) -> None:
@@ -77,3 +82,18 @@ def put(question: str, answer, options=None) -> None:
         os.replace(tmp, PATH)
     except Exception:
         pass                                # a cache we cannot write is a slow bot, not a broken one
+
+
+def record(question: str, kind: str, options=None) -> bool:
+    '''
+    Add a question nothing could answer to the file as a worklist entry, and say whether
+    it was new. Type and options ride along because a bare question is not enough to
+    answer one by hand - "Yes" is the wrong shape for a "0-1 / 2-5 / 5+" dropdown.
+
+    An entry that already carries an answer is left alone: the user's own edit is never
+    overwritten by a later run that got blocked on the same question.
+    '''
+    if get(question, options) not in (MISS, None):
+        return False
+    put(question, {"answer": None, "type": kind, "options": list(options or [])}, options)
+    return True

--- a/modules/ai/cache.py
+++ b/modules/ai/cache.py
@@ -1,0 +1,79 @@
+'''
+Author:     Sai Vignesh Golla
+License:    MIT License  (https://opensource.org/license/mit)
+GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
+
+Persistent answer cache for the local AI layer.
+
+LinkedIn Easy Apply asks the same ~50 questions across every job, so the cheapest
+model call is the one never made: a hit costs zero model time and turns a whole
+job into free work. Plain JSON at the project root, stdlib only.
+
+The file is meant to be HAND-EDITED, which is why keys carry the readable
+question and not just a digest, and why a "no truthful answer" result is stored
+as `null` rather than dropped - the null entries are the worklist of questions
+worth answering yourself in config/questions.py.
+
+It holds the user's own answers, so it is gitignored and written 0600.
+'''
+
+import hashlib
+import json
+import os
+import re
+
+# modules/ai/cache.py -> modules/ai -> modules -> project root
+PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+                    ".ai_answer_cache.json")
+
+MISS = object()     # distinct from a stored `None`, which means "asked, no truthful answer"
+
+_data = None
+_whitespace = re.compile(r"\s+")
+
+
+def _norm(text) -> str:
+    '''Lowercase, collapse whitespace, drop LinkedIn's required-field decoration.'''
+    return _whitespace.sub(" ", str(text or "").strip().lower()).strip(" \t*?:.")
+
+
+def key(question: str, options=None) -> str:
+    '''
+    `<readable question>#<digest>`. The digest covers the normalised question AND the
+    normalised option list, so the same wording with a different option set is a
+    different entry - answering "Yes/No" is not the same as answering "0-1/2-5/5+".
+    '''
+    question = _norm(question)
+    digest = hashlib.sha1(json.dumps([question, [_norm(o) for o in (options or [])]]).encode()).hexdigest()[:8]
+    return f"{question[:70]}#{digest}"
+
+
+def _load() -> dict:
+    global _data
+    if _data is None:
+        try:
+            with open(PATH, encoding="utf-8") as f:
+                loaded = json.load(f)
+            _data = loaded if isinstance(loaded, dict) else {}
+        except Exception:
+            _data = {}                      # absent, empty or hand-edited into invalid JSON
+    return _data
+
+
+def get(question: str, options=None):
+    '''Stored answer, or `MISS`. A stored `None` is a real result: asked, no truthful answer.'''
+    return _load().get(key(question, options), MISS)
+
+
+def put(question: str, answer, options=None) -> None:
+    '''Store an answer. Written via a temp file chmod-ed before the rename, so the
+    real answers are never briefly world-readable.'''
+    _load()[key(question, options)] = answer
+    tmp = PATH + ".tmp"
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(_data, f, indent=1, sort_keys=True, ensure_ascii=False)
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, PATH)
+    except Exception:
+        pass                                # a cache we cannot write is a slow bot, not a broken one

--- a/modules/ai/connections.py
+++ b/modules/ai/connections.py
@@ -167,7 +167,7 @@ class ExtractedSkills(BaseModel):
     nice_to_have: list[str] = Field(default_factory=list, description="Skills listed as preferred or beneficial but not mandatory")
 
 
-def extract_skills(client: Optional[AIClient], job_description: str, stream: bool = False) -> dict:
+def extract_skills(client: Optional[AIClient], job_description: str) -> dict:
     '''
     Extract and classify skills from a job description.
     Returns a dict with the five skill buckets, or an ``{"error": ...}`` dict on failure.
@@ -197,7 +197,6 @@ class _AnswerState(TypedDict, total=False):
     options: Optional[list]
     question_type: str
     job_description: Optional[str]
-    about_company: Optional[str]
     user_information: Optional[str]
     prompt: str
     raw: str
@@ -208,20 +207,19 @@ def _build_answer_graph(model):
     '''
     Compile a small LangGraph pipeline for answering a form question:
 
-        build_prompt -> generate -> (route by question type) -> format_text | select_option
+        build_prompt -> generate -> format_text
 
-    Free-text questions are returned as-is; select questions are snapped to one of
-    the allowed options. The graph gives us a clean seam to extend later (validation,
-    retries, resume/cover-letter nodes).
+    Free text only. There was a select_option node that snapped the model's reply to an
+    allowed option and fell back to `return {"answer": raw}` - an unvalidated model string
+    straight into a form field, i.e. a guess. Nothing ever reached it (runAiBot only ever
+    passes question_type "text"/"textarea"; dropdowns and radios go through
+    match_answer_to_option), so it is gone rather than left armed.
     '''
     def build_prompt(state: _AnswerState) -> dict:
         prompt = ai_answer_prompt.format(state.get("user_information") or "N/A", state.get("question") or "")
         jd = state.get("job_description")
         if jd and jd != "Unknown":
             prompt += f"\n\nJob description:\n{jd}"
-        about = state.get("about_company")
-        if about and about != "Unknown":
-            prompt += f"\n\nAbout the company:\n{about}"
         options = state.get("options")
         if options:
             prompt += "\n\nAnswer with exactly one of these options:\n" + "\n".join(f"- {o}" for o in options)
@@ -234,34 +232,14 @@ def _build_answer_graph(model):
     def format_text(state: _AnswerState) -> dict:
         return {"answer": (state.get("raw") or "").strip()}
 
-    def select_option(state: _AnswerState) -> dict:
-        raw = (state.get("raw") or "").strip()
-        options = state.get("options") or []
-        for opt in options:                       # exact
-            if raw == opt:
-                return {"answer": opt}
-        low = raw.lower()
-        for opt in options:                       # case-insensitive
-            if low == opt.lower():
-                return {"answer": opt}
-        for opt in options:                       # substring (either direction)
-            if opt.lower() in low or low in opt.lower():
-                return {"answer": opt}
-        return {"answer": raw}
-
-    def route(state: _AnswerState) -> str:
-        return "select" if state.get("question_type") in ("single_select", "multiple_select") else "text"
-
     graph = StateGraph(_AnswerState)
     graph.add_node("build_prompt", build_prompt)
     graph.add_node("generate", generate)
     graph.add_node("format_text", format_text)
-    graph.add_node("select_option", select_option)
     graph.add_edge(START, "build_prompt")
     graph.add_edge("build_prompt", "generate")
-    graph.add_conditional_edges("generate", route, {"text": "format_text", "select": "select_option"})
+    graph.add_edge("generate", "format_text")
     graph.add_edge("format_text", END)
-    graph.add_edge("select_option", END)
     return graph.compile()
 
 
@@ -271,9 +249,7 @@ def answer_question(
     options: Optional[list] = None,
     question_type: str = "text",
     job_description: Optional[str] = None,
-    about_company: Optional[str] = None,
     user_information_all: Optional[str] = None,
-    stream: bool = False,
 ) -> str:
     '''
     Generate an answer to a single application-form question.
@@ -287,7 +263,6 @@ def answer_question(
             "options": options,
             "question_type": question_type,
             "job_description": job_description,
-            "about_company": about_company,
             "user_information": user_information_all,
         })
         answer = final.get("answer", "") or ""

--- a/modules/ai/fit.py
+++ b/modules/ai/fit.py
@@ -1,0 +1,46 @@
+'''
+Author:     Sai Vignesh Golla
+License:    MIT License  (https://opensource.org/license/mit)
+GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
+
+Job-fit scoring, and the ONE way AI is allowed near the skip decision.
+
+THE INVARIANT
+-------------
+`get_job_description` in runAiBot.py skips jobs on citizenship, clearance,
+sponsorship and experience grounds. Those filters are deterministic, they are
+the reason a CV did not go to a role the applicant is not legally allowed to
+hold, and a 4B local model must NEVER be able to un-skip one.
+
+So the combination is `deterministic_skip or ai_skip`. Never `and`, never a
+model vote that outranks a rule. The AI's whole power here is to skip MORE.
+`should_skip` is the only function that combines them and it is pinned by test.
+'''
+
+from modules.helpers import logger
+from modules.ai.local import score_fit
+
+
+def should_skip(deterministic_skip: bool, job_description: str, facts: str,
+                min_score: int = 0, scorer=score_fit) -> tuple:
+    '''
+    `(skip, reason)` for one job.
+
+    `skip` is `deterministic_skip or ai_skip` - the AI may only ADD a skip.
+    A deterministic skip short-circuits, so the common rejection path stays free
+    of model time. `min_score` of 0 disables AI skipping entirely (the default:
+    scoring is advisory until the user opts in). A scorer that returns None -
+    server down, timeout, unparseable - contributes no skip.
+    '''
+    if deterministic_skip:
+        return True, None                       # already skipped; a model call would change nothing
+    if min_score <= 0 or not job_description:
+        return False, None
+    scored = scorer(job_description, facts)
+    if scored is None:
+        return False, None                      # no score is not a reason to skip
+    score, why = scored
+    if score >= min_score:
+        return False, None
+    logger.warning("AI fit score %s < %s: %s", score, min_score, why)
+    return True, f"AI fit score {score}/100 below {min_score} ({why})"

--- a/modules/ai/local.py
+++ b/modules/ai/local.py
@@ -69,6 +69,8 @@ def _cfg_get(name: str, default: str) -> str:
 # 2.85 GB model on the first request.
 TIERS = {1: (8, 30), 2: (128, 60), 3: (512, 120)}
 
+_down = False       # set once the server proves unreachable; see `_chat`
+
 
 def _chat(system: str, user: str, schema: dict, tier: int):
     '''
@@ -79,6 +81,12 @@ def _chat(system: str, user: str, schema: dict, tier: int):
     profile block, so LM Studio's prompt prefix cache skips re-prefilling both
     across calls. Never interpolate variable text into `system`.
     '''
+    global _down
+    # Nothing is listening and nothing in a run will change that, so the first refusal
+    # ends it. Without this every question of every job pays another connect attempt, and
+    # a DNS miss or a firewalled host pays it in seconds rather than microseconds.
+    if _down:
+        return None
     max_tokens, timeout = TIERS[tier]
     body = {
         "model": _cfg_get("local_llm_model", "qwen/qwen3.5-4b"),
@@ -100,6 +108,10 @@ def _chat(system: str, user: str, schema: dict, tier: int):
         return parsed if isinstance(parsed, dict) else None
     except Exception as e:
         # Down, hung, or talking nonsense - all the same to the caller: no answer.
+        # A connect-level OSError (refused, unreachable, DNS) means there is no server;
+        # a TimeoutError does NOT - LM Studio just-in-time loads the model, so the first
+        # call against a working server can legitimately run long.
+        _down = isinstance(getattr(e, "reason", None), OSError) and not isinstance(e.reason, TimeoutError)
         logger.warning("Local AI tier %s call failed, falling through to no answer. %s", tier, e)
         return None
 

--- a/modules/ai/local.py
+++ b/modules/ai/local.py
@@ -246,3 +246,67 @@ def score_fit(job_description: str, facts: str, ask=_chat):
     if not isinstance(score, int) or isinstance(score, bool) or not 0 <= score <= 100:
         return None
     return score, str(result.get("r") or "").strip()
+
+
+# --------------------------------------------------------------------------- #
+# Startup nudge.  Most users never switch AI on because they assume it costs
+# money, and a local model does not. Shown once per run and by the control panel.
+# --------------------------------------------------------------------------- #
+# Both speak the OpenAI-compatible /v1 API, so one probe shape covers the pair.
+LOCAL_SERVERS = (("LM Studio", "http://127.0.0.1:1234/v1"),
+                 ("Ollama", "http://127.0.0.1:11434/v1"))
+
+_READY = ('{name} is already running on this computer, but "Use AI" is switched off, so '
+          'the tool is not using it.\n\n'
+          'Turn "Use AI" on (use_AI = True in config/secrets.py) and set "Local AI server '
+          'URL" to {url}. It then answers the application questions your config does not '
+          'cover, and it costs nothing - the model runs on your own machine.')
+
+_OFF = ('AI is switched off, so the tool can only answer the application questions your '
+        'config already covers. Anything else is left blank and reported.\n\n'
+        'If the worry is cost, it does not have to cost anything. Install LM Studio '
+        '(https://lmstudio.ai) or Ollama (https://ollama.com), download a small model - a '
+        '4B-class one is plenty and runs on a normal laptop - and turn "Use AI" on.')
+
+_BROKEN = ('"Use AI" is on, but no local model server answered and no API key is set, so '
+           'every question your config does not cover will be left unanswered.\n\n'
+           'Start LM Studio (https://lmstudio.ai) or Ollama (https://ollama.com) and point '
+           '"Local AI server URL" at it, or paste a real key into "AI API key".')
+
+
+def local_server_running(timeout: float = 0.5):
+    '''
+    `(name, base url)` of the first local model server that answers, or None.
+
+    Runs on the startup path, so it NEVER raises and never costs more than
+    `timeout` per port: a port nothing is listening on refuses immediately, and
+    the timeout caps a firewalled or black-holed one. Two ports, ~1s worst case.
+    '''
+    for name, url in LOCAL_SERVERS:
+        try:
+            urllib.request.urlopen(url + "/models", timeout=timeout).close()
+            return name, url
+        except Exception:
+            pass                    # not there, not ours, or too slow to be worth waiting on
+    return None
+
+
+def ai_suggestion(use_ai: bool, api_key: str = "", probe=local_server_running):
+    '''
+    `(state, message)` for the "you could be using AI" nudge, or None when there is
+    nothing worth saying. `probe` is injected so tests never open a socket.
+
+      "ready"   a local server is up and `use_AI` is simply off - one flip away.
+      "off"     nothing configured at all, and it could be free.
+      "broken"  `use_AI` is on but nothing answers, so answers silently fall through.
+
+    A configured API key with `use_AI` off says nothing: that user already knows what
+    AI costs and turned it off on purpose. The pitch here is only that it can be free.
+    '''
+    server = probe()
+    has_key = (api_key or "").strip().lower() not in ("", "not-needed")
+    if use_ai:
+        return None if (server or has_key) else ("broken", _BROKEN)
+    if server:
+        return "ready", _READY.format(name=server[0], url=server[1])
+    return None if has_key else ("off", _OFF)

--- a/modules/ai/local.py
+++ b/modules/ai/local.py
@@ -1,0 +1,236 @@
+'''
+Author:     Sai Vignesh Golla
+License:    MIT License  (https://opensource.org/license/mit)
+GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
+
+Local-model answer layer for Easy Apply questions.
+
+WHY THIS IS NOT modules/ai/connections.py
+-----------------------------------------
+`connections.py` is the provider-agnostic cloud path (LangChain -> OpenAI /
+Gemini / anything OpenAI-compatible) and it stays exactly as it is. This module
+is the latency-critical LOCAL path, and it needs three things on the wire that
+LangChain would have us fight its abstraction for:
+
+  * `chat_template_kwargs: {"enable_thinking": false}` - Qwen3.5 thinks by
+    default. Measured 2026-09-10: with thinking ON the model burned all 300
+    tokens without finishing its JSON; OFF it finished in 250. It is a token
+    COUNT problem, not a speed one.
+  * a raw `response_format: {"type": "json_schema", ...}` - constrained
+    decoding, which LangChain reaches only through its tool-calling
+    `with_structured_output` path. A 4B asked nicely for JSON drifts; a 4B under
+    a grammar cannot. Shape is enforced by the schema, not by prompt wording.
+  * `max_retries = 0` and a hard per-call timeout. LangChain's ChatOpenAI
+    retries twice by default, which TRIPLES the worst case against a server that
+    is down - on a live job application, with the browser sitting idle.
+
+All three are one dict key each with `urllib.request`, which is also what
+`check_local_llm.py` speaks. So: stdlib, ~40 lines, no new dependency, and the
+request shape is readable at a glance.
+
+THE COST MODEL THAT SHAPES EVERY TIER
+-------------------------------------
+Qwen3.5-4B 4-bit on an M4 16GB, measured: ~158 tok/s prefill, ~20.6 tok/s
+generation. GENERATED tokens are the bill. So each question is pushed down to
+the cheapest tier that can answer it:
+
+  Tier 0  free      the deterministic ladder in runAiBot.py already answers it,
+                    or the cache has it. No model call. This is the common case.
+  Tier 1  ~7 tok    constrained choice for select/radio: an option number or
+                    NONE, under an enum grammar.  ~0.4s + prefill.
+  Tier 2  ~30-80    short free text.               ~2-4s + prefill.
+  Tier 3  ~200-500  long form, cached once per company. ~10-25s.
+
+NOTHING HERE IS ALLOWED TO RAISE INTO THE APPLY LOOP. Every failure - server
+down, timeout, garbage, schema refusal - returns None, and the caller falls
+through to the bot's existing never-guess behaviour.
+'''
+
+import json
+import urllib.request
+
+from modules.helpers import logger
+from modules.ai import cache
+from modules.ai.prompts import (local_select_system, local_text_system,
+                                local_long_system, local_fit_system)
+
+try:
+    import config.secrets as _cfg
+except Exception:                                   # importable without a configured checkout
+    _cfg = None
+
+
+def _cfg_get(name: str, default: str) -> str:
+    return (getattr(_cfg, name, "") or "").strip() or default
+
+
+# tier -> (max_tokens, timeout_seconds). The timeouts are hang guards, not latency
+# targets: they are sized for a cold start, where LM Studio just-in-time loads the
+# 2.85 GB model on the first request.
+TIERS = {1: (8, 30), 2: (128, 60), 3: (512, 120)}
+
+
+def _chat(system: str, user: str, schema: dict, tier: int):
+    '''
+    One OpenAI-compatible chat completion under a JSON-schema grammar.
+    Returns the parsed object, or None on ANY failure.
+
+    `system` is a static per-tier prefix and `user` starts with the equally static
+    profile block, so LM Studio's prompt prefix cache skips re-prefilling both
+    across calls. Never interpolate variable text into `system`.
+    '''
+    max_tokens, timeout = TIERS[tier]
+    body = {
+        "model": _cfg_get("local_llm_model", "qwen/qwen3.5-4b"),
+        "messages": [{"role": "system", "content": system}, {"role": "user", "content": user}],
+        "response_format": {"type": "json_schema",
+                            "json_schema": {"name": "answer", "strict": True, "schema": schema}},
+        "chat_template_kwargs": {"enable_thinking": False},
+        "max_tokens": max_tokens,
+        "temperature": 0,
+    }
+    url = _cfg_get("local_llm_api_url", "http://127.0.0.1:1234/v1").rstrip("/") + "/chat/completions"
+    request = urllib.request.Request(
+        url, data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json",
+                 "Authorization": "Bearer " + _cfg_get("llm_api_key", "not-needed")})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            parsed = json.loads(json.load(response)["choices"][0]["message"]["content"])
+        return parsed if isinstance(parsed, dict) else None
+    except Exception as e:
+        # Down, hung, or talking nonsense - all the same to the caller: no answer.
+        logger.warning("Local AI tier %s call failed, falling through to no answer. %s", tier, e)
+        return None
+
+
+def profile_block(facts: dict) -> str:
+    '''
+    The compact fact block. Deliberately NOT the whole profile: no cover letter, no
+    LinkedIn summary, no job description. Those are tier 3's problem.
+
+    It is fixed for a whole run on purpose. Selecting fields per question would save
+    ~50 prefill tokens (~0.3s) but change the prefix on every call, which costs the
+    LM Studio prefix cache - far more than it saves. See the report.
+    '''
+    return "\n".join(f"{k}: {v}" for k, v in facts.items() if v not in (None, "", "Unknown"))
+
+
+def default_facts() -> dict:
+    '''
+    Facts read LITERALLY from config, never inferred by a model. Four of five model
+    configs invented an email, a LinkedIn URL and the wrong city when the contact
+    block was absent from the prompt, so it is always present and always literal.
+    '''
+    import config.personals as p
+    import config.questions as q
+    return {
+        "Name": f"{p.first_name} {p.last_name}",
+        "Location": f"{p.current_city or ''} {p.state}, {p.country}".strip(),
+        "Total years of professional experience": q.years_of_experience,
+        "Needs visa sponsorship": q.require_visa,
+        "Legally authorized to work here": q.legally_authorized,
+        "Citizenship status": q.us_citizenship,
+        "Notice period (days)": q.notice_period,
+        "Desired salary": q.desired_salary,
+        "Headline": q.linkedin_headline,
+        "Gender": p.gender, "Ethnicity": p.ethnicity,
+        "Disability status": p.disability_status, "Veteran status": p.veteran_status,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Tier 1 - constrained choice.  AI proposes, the deterministic validator disposes.
+# --------------------------------------------------------------------------- #
+def answer_select(question: str, option_texts: list, validator, facts: str, ask=_chat):
+    '''
+    Index into `option_texts`, or None to LEAVE THE CONTROL UNTOUCHED.
+
+    `validator` is runAiBot's `match_answer_to_option`, passed in rather than imported
+    (importing runAiBot opens Chrome). It runs on EVERY proposal, including a cache
+    hit, so the AI can never write a value the deterministic matcher would have
+    rejected and a hand-edited cache cannot smuggle one in either. None here is the
+    same None the config ladder produces, and takes the same never-guess path.
+    '''
+    if not question or not option_texts:
+        return None
+
+    proposal = cache.get(question, option_texts)
+    if proposal is cache.MISS:
+        numbered = "\n".join(f"{i}. {text}" for i, text in enumerate(option_texts, 1))
+        # Variable tail only; the static rules live in the system prompt.
+        result = ask(local_select_system,
+                     f"{facts}\n\nQuestion: {question}\n\nOptions:\n{numbered}",
+                     {"type": "object", "additionalProperties": False, "required": ["o"],
+                      "properties": {"o": {"type": "string",
+                                           "enum": [str(i) for i in range(1, len(option_texts) + 1)] + ["NONE"]}}},
+                     1)
+        choice = (result or {}).get("o")
+        # The enum makes anything else impossible, but a non-conforming server is not.
+        proposal = option_texts[int(choice) - 1] if str(choice).isdigit() and 0 < int(choice) <= len(option_texts) else None
+        cache.put(question, proposal, option_texts)
+
+    matched = validator(proposal, option_texts)
+    if matched is None and proposal:
+        logger.warning('AI proposed "%s" for "%s", which matches no real option. Leaving it untouched.',
+                       proposal, question)
+    return matched
+
+
+# --------------------------------------------------------------------------- #
+# Tier 2 - short free text.
+# --------------------------------------------------------------------------- #
+def answer_text(question: str, facts: str, ask=_chat):
+    '''The answer string, or None to leave the field empty and report it.'''
+    if not question:
+        return None
+    answer = cache.get(question)
+    if answer is cache.MISS:
+        result = ask(local_text_system, f"{facts}\n\nQuestion: {question}",
+                     {"type": "object", "additionalProperties": False, "required": ["a"],
+                      "properties": {"a": {"type": "string"}}}, 2)
+        answer = str((result or {}).get("a") or "").strip()
+        answer = None if not answer or answer.upper() == "NONE" else answer
+        cache.put(question, answer)
+    return answer
+
+
+# --------------------------------------------------------------------------- #
+# Tier 3 - long form. Expensive, so cached once per company, not per question.
+# --------------------------------------------------------------------------- #
+def answer_long(kind: str, company: str, facts: str, job_description: str = "", ask=_chat):
+    '''Cover letter / summary text for one company, or None. ~10-25s on a miss.'''
+    entry = f"{kind} @ {company}"
+    answer = cache.get(entry)
+    if answer is cache.MISS:
+        # Truncated: prefill is 158 tok/s, so a full 1200-token JD is ~8s before the
+        # first output token. The first 2000 characters carry the role and the asks.
+        result = ask(local_long_system,
+                     f"{facts}\n\nWrite: {kind}\n\nRole at {company}:\n{(job_description or '')[:2000]}",
+                     {"type": "object", "additionalProperties": False, "required": ["t"],
+                      "properties": {"t": {"type": "string"}}}, 3)
+        answer = str((result or {}).get("t") or "").strip() or None
+        cache.put(entry, answer)
+    return answer
+
+
+# --------------------------------------------------------------------------- #
+# Fit score.  Kept here so `fit.py` stays about the skip decision, not transport.
+# --------------------------------------------------------------------------- #
+def score_fit(job_description: str, facts: str, ask=_chat):
+    '''
+    `(score 0-100, one-line reason)`, or None. A parse failure is None, never a score.
+
+    Tier 2, not tier 1: the reason string pushes this to ~20 output tokens and tier 1's
+    8-token cap would truncate the JSON mid-object. max_tokens is a ceiling, not a
+    target - the grammar closes the object as soon as "r" ends, so the wider cap costs
+    nothing on a well-behaved reply.
+    '''
+    result = ask(local_fit_system, f"{facts}\n\nRole:\n{(job_description or '')[:2000]}",
+                 {"type": "object", "additionalProperties": False, "required": ["s", "r"],
+                  "properties": {"s": {"type": "integer", "minimum": 0, "maximum": 100},
+                                 "r": {"type": "string"}}}, 2)
+    score = (result or {}).get("s")
+    if not isinstance(score, int) or isinstance(score, bool) or not 0 <= score <= 100:
+        return None
+    return score, str(result.get("r") or "").strip()

--- a/modules/ai/prompts.py
+++ b/modules/ai/prompts.py
@@ -48,3 +48,51 @@ Question:
 {}
 """
 #<
+
+
+# =========================================================================== #
+# Local-model prompts (modules/ai/local.py)
+#
+# Written for a SMALL local model - Qwen3.5-4B 4-bit at ~20 tok/s generation,
+# ~158 tok/s prefill (measured 2026-09-10, see LOCAL-LLM-HANDOFF.md). Three
+# rules a 4B follows; eight it does not. Every rule below earns its tokens:
+#
+#   - Output SHAPE is enforced by `response_format` json_schema (constrained
+#     decoding), never by asking politely. So these prompts carry no "reply in
+#     JSON", no "no markdown fences", no "do not restate the question" - the
+#     grammar makes those outcomes impossible and the words would be paid for
+#     on every single call.
+#   - Each block is a STATIC prefix. The variable tail (profile, question,
+#     options, job description) is appended by the caller so LM Studio's prompt
+#     prefix cache survives across calls. Never interpolate into these strings.
+#   - "truthful" is load-bearing, not decoration. It is the word that produces
+#     NONE instead of a plausible invention, and NONE is what preserves the
+#     bot's never-guess property.
+# =========================================================================== #
+
+##> Tier 1 - constrained choice for <select> and radio groups. ~7 output tokens.
+local_select_system = """You fill in job application forms for one candidate.
+Choose the option number that is TRUTHFUL for this candidate.
+If no option is truthful, or the facts below do not say, choose NONE."""
+#<
+
+
+##> Tier 2 - short free text for text inputs. ~30-80 output tokens.
+local_text_system = """You fill in job application forms for one candidate.
+Answer in the candidate's own voice, using only the facts below.
+If the question asks for a number, answer with digits only.
+If the facts do not contain a truthful answer, answer exactly NONE."""
+#<
+
+
+##> Tier 3 - long form, cached once per company. ~200-500 output tokens.
+local_long_system = """Write the requested application text for this candidate.
+Use only the facts and role summary below - invent no employer, skill or date.
+Under 900 characters, plain prose, no salutation and no sign-off."""
+#<
+
+
+##> Fit score - one number and one short reason. ~20 output tokens.
+local_fit_system = """Score how well this candidate matches this role.
+"s" is 0-100. "r" is the single strongest reason, under 12 words."""
+#<

--- a/modules/clickers_and_finders.py
+++ b/modules/clickers_and_finders.py
@@ -10,8 +10,6 @@ License:    MIT License
 GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
 
 Support me: https://github.com/sponsors/GodsScion
-
-version:    26.01.20.5.08
 '''
 
 from config.settings import click_gap, smooth_scroll
@@ -91,21 +89,6 @@ def wait_xp_click(driver: WebDriver | WebElement, xpath: str, time: float=5.0, s
         logger.warning('Click Failed! Nothing visible matching "%s" (%s)', xpath, type(e).__name__)
         return False
 
-def multi_sel(driver: WebDriver, texts: list, time: float=5.0) -> None:
-    '''
-    - For each text in the `texts`, tries to find and click `span` element with that text.
-    - Will spend a max of `time` seconds in searching for each element.
-    '''
-    for text in texts:
-        wait_span_click(driver, text, time, False)
-        try:
-            button = wait_for_displayed(driver, text_xpath("span", text), time)
-            scroll_to_view(driver, button)
-            button.click()
-            buffer(click_gap)
-        except Exception as e:
-            logger.warning("Click Failed! Didn't find '%s' (%s)", text, type(e).__name__)
-
 def multi_sel_noWait(driver: WebDriver, texts: list, actions: ActionChains = None) -> None:
     '''
     - For each text in the `texts`, tries to find and click `span` element with that class.
@@ -158,16 +141,6 @@ def scroll_to_view(driver: WebDriver, element: WebElement, top: bool = False, sm
         return driver.execute_script('arguments[0].scrollIntoView();', element)
     behavior = "smooth" if smooth_scroll else "instant"
     return driver.execute_script('arguments[0].scrollIntoView({block: "center", behavior: "'+behavior+'" });', element)
-
-# Enter input text functions
-def text_input_by_ID(driver: WebDriver, id: str, value: str, time: float=5.0) -> None | Exception:
-    '''
-    Enters `value` into the input field with the given `id` if found, else throws NotFoundException.
-    - `time` is the max time to wait for the element to be found.
-    '''
-    username_field = WebDriverWait(driver, time).until(EC.presence_of_element_located((By.ID, id)))
-    username_field.send_keys(Keys.CONTROL + "a")
-    human_type(username_field, value)
 
 def try_xp(driver: WebDriver, xpath: str, click: bool=True) -> WebElement | bool:
     try:

--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -10,8 +10,6 @@ License:    MIT License
 GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
 
 Support me: https://github.com/sponsors/GodsScion
-
-version:    26.01.20.5.08
 '''
 
 

--- a/modules/open_chrome.py
+++ b/modules/open_chrome.py
@@ -10,8 +10,6 @@ License:    MIT License
 GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
 
 Support me: https://github.com/sponsors/GodsScion
-
-version:    26.01.20.5.08
 '''
 
 from modules.helpers import get_default_temp_profile, make_directories

--- a/modules/open_chrome.py
+++ b/modules/open_chrome.py
@@ -100,20 +100,30 @@ def createChromeSession(isRetry: bool = False):
     actions = ActionChains(driver)
     return options, driver, actions, wait
 
-try:
-    options, driver, actions, wait = None, None, None, None
-    options, driver, actions, wait = createChromeSession()
-except SessionNotCreatedException as e:
-    # Recoverable: the guest-profile retry below usually succeeds, so this is not an ERROR.
-    logger.warning("Failed to create Chrome Session, retrying with guest profile", exc_info=e)
-    options, driver, actions, wait = createChromeSession(True)
-except Exception as e:
-    msg = 'Seems like Google Chrome is out dated. Update browser and try again! \n\n\nIf issue persists, try Safe Mode. Set, safe_mode = True in config.py \n\nPlease check GitHub discussions/support for solutions https://github.com/GodsScion/Auto_job_applier_linkedIn \n                                   OR \nReach out in discord ( https://discord.gg/fFp7uUzWCY )'
-    if isinstance(e,TimeoutError): msg = "Couldn't download Chrome-driver. Set auto_manage_driver = False in config!"
-    logger.error(msg)
-    critical_error_log("In Opening Chrome", e)
-    from pyautogui import alert
-    alert(msg, "Error in opening chrome")
-    try: driver.quit()
-    except NameError: exit()
-    
+# Populated by start_browser(), never at import. Importing this module used to open a
+# real browser as a side effect, so `import runAiBot` launched Chrome before main() could
+# run validate_config() - a bad config cost you a browser window and a driver download.
+options, driver, actions, wait = None, None, None, None
+
+
+def start_browser() -> tuple:
+    '''Open the Chrome session and publish it as this module's options/driver/actions/wait.'''
+    global options, driver, actions, wait
+    try:
+        options, driver, actions, wait = createChromeSession()
+    except SessionNotCreatedException as e:
+        # Recoverable: the guest-profile retry below usually succeeds, so this is not an ERROR.
+        logger.warning("Failed to create Chrome Session, retrying with guest profile", exc_info=e)
+        options, driver, actions, wait = createChromeSession(True)
+    except Exception as e:
+        msg = 'Seems like Google Chrome is out dated. Update browser and try again! \n\n\nIf issue persists, try Safe Mode. Set, safe_mode = True in config.py \n\nPlease check GitHub discussions/support for solutions https://github.com/GodsScion/Auto_job_applier_linkedIn \n                                   OR \nReach out in discord ( https://discord.gg/fFp7uUzWCY )'
+        if isinstance(e,TimeoutError): msg = "Couldn't download Chrome-driver. Set auto_manage_driver = False in config!"
+        logger.error(msg)
+        critical_error_log("In Opening Chrome", e)
+        from pyautogui import alert
+        alert(msg, "Error in opening chrome")
+        # `driver` is None unless the session got far enough to hand one back; the old
+        # `except NameError` here could never fire and raised AttributeError instead.
+        if driver: driver.quit()
+        exit()
+    return options, driver, actions, wait

--- a/modules/updater.py
+++ b/modules/updater.py
@@ -4,8 +4,6 @@ License:    MIT License
             https://opensource.org/license/mit
 GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
 
-version:    26.01.20.5.08
-
 Update check for the control panel: compare the local VERSION file with the one
 on the default branch, and offer a one-button `git pull` to fast-forward.
 

--- a/modules/validator.py
+++ b/modules/validator.py
@@ -10,8 +10,6 @@ License:    MIT License
 GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
 
 Support me: https://github.com/sponsors/GodsScion
-
-version:    26.01.20.5.08
 '''
 
 

--- a/modules/validator.py
+++ b/modules/validator.py
@@ -66,7 +66,7 @@ def validate_personals() -> None | ValueError | TypeError:
     check_string(zipcode, "zipcode")
     check_string(country, "country")
     
-    check_string(ethnicity, "ethnicity", ["Decline", "Hispanic/Latino", "American Indian or Alaska Native", "Asian", "Black or African American", "Native Hawaiian or Other Pacific Islander", "White", "Other"],  min_length=0)
+    check_string(ethnicity, "ethnicity", ["", "Decline", "Hispanic/Latino", "American Indian or Alaska Native", "Asian", "Black or African American", "Native Hawaiian or Other Pacific Islander", "White", "Other"],  min_length=0)
     check_string(gender, "gender", ["Male", "Female", "Other", "Decline", ""])
     check_string(disability_status, "disability_status", ["Yes", "No", "Decline"])
     check_string(veteran_status, "veteran_status", ["Yes", "No", "Decline"])
@@ -116,7 +116,7 @@ def validate_search() -> None | ValueError | TypeError:
 
     check_string(sort_by, "sort_by", ["", "Most recent", "Most relevant"])
     check_string(date_posted, "date_posted", ["", "Any time", "Past month", "Past week", "Past 24 hours"])
-    check_string(salary, "salary")
+    check_string(salary, "salary", ["", "$40,000+", "$60,000+", "$80,000+", "$100,000+", "$120,000+", "$140,000+", "$160,000+", "$180,000+", "$200,000+"])
 
     check_boolean(easy_apply_only, "easy_apply_only")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,3 @@ langgraph==1.2.10                # graph orchestration for the question-answer p
 
 # Local applied-jobs history web UI (app.py)
 flask
-flask-cors

--- a/runAiBot.py
+++ b/runAiBot.py
@@ -892,12 +892,18 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
                         print_lg(f'No answer for the text question "{label_org}". Leaving it empty - add it to config/questions.py.')
                         randomly_answered_questions.add((label_org, "text"))
                         unanswered_questions.add(label_org)
-                text.clear()
-                human_type(text, answer)
-                if do_actions:
-                    sleep(2)
-                    actions.send_keys(Keys.ARROW_DOWN)
-                    actions.send_keys(Keys.ENTER).perform()
+                # Only touch the control when we actually determined an answer. On the
+                # never-guess path above `answer` is still "", and clear()+human_type("")
+                # wipes whatever was there - LinkedIn's own prefill of the email, phone or
+                # city box - and submits it blank. `!= ""` and not truthiness: a notice
+                # period or salary of 0 is a real answer.
+                if answer != "":
+                    text.clear()
+                    human_type(text, answer)
+                    if do_actions:
+                        sleep(2)
+                        actions.send_keys(Keys.ARROW_DOWN)
+                        actions.send_keys(Keys.ENTER).perform()
             questions_list.add((label, text.get_attribute("value"), "text", prev_answer))
             continue
 
@@ -925,8 +931,13 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
                     else:
                         randomly_answered_questions.add((label_org, "textarea"))
                         unanswered_questions.add(label_org)
-            text_area.clear()
-            human_type(text_area, answer)
+                # Both of these sat at indent 12, OUTSIDE the gate above. So a textarea the
+                # user had already filled in was emptied even with overwrite_previous_answers
+                # off, and an unrecognised question - which reports itself and answers "" -
+                # was emptied too and submitted blank. Same guard as the text branch.
+                if answer != "":
+                    text_area.clear()
+                    human_type(text_area, answer)
             questions_list.add((label, text_area.get_attribute("value"), "textarea", prev_answer))
             continue
 

--- a/runAiBot.py
+++ b/runAiBot.py
@@ -37,7 +37,7 @@ from selenium.common.exceptions import NoSuchElementException, ElementClickInter
 from config.personals import *
 from config.questions import *
 from config.search import *
-from config.secrets import use_AI, username, password, ai_provider
+from config.secrets import use_AI, username, password, ai_provider, llm_api_key
 from config.settings import *
 
 from modules.open_chrome import *
@@ -1623,8 +1623,28 @@ def run(total_runs: int) -> int:
 
 linkedIn_tab = False
 
+
+def suggest_ai() -> None:
+    '''
+    One dialog at startup about what AI would answer and how to get it for free.
+
+    Both gates matter. `interactive_session` is already False for a headless run and
+    for the control panel's Popen, where `pyautogui.alert` is a no-op print - checking
+    it HERE means such a run also skips the probe, so it costs nothing rather than a
+    second of sockets for a dialog nobody will see. `show_ai_suggestion` is the
+    permanent off switch, and it is checked before the probe for the same reason.
+    '''
+    if not (show_ai_suggestion and interactive_session):
+        return
+    found = local.ai_suggestion(use_AI, llm_api_key)
+    if found:
+        pyautogui.alert(found[1], "AI is on, but nothing is answering" if found[0] == "broken"
+                        else "You could be using AI", "Okay")
+
+
 def main() -> None:
     pyautogui.alert("Please consider sponsoring this project at:\n\nhttps://github.com/sponsors/GodsScion\n\n", "Support the project", "Okay")
+    suggest_ai()
     total_runs = 1
     try:
         global linkedIn_tab, tabs_count, useNewResume, aiClient, options, driver, actions, wait

--- a/runAiBot.py
+++ b/runAiBot.py
@@ -716,6 +716,17 @@ def _ask_model(*args):
     return local._chat(*args) if use_AI else None
 
 
+def real_options(option_texts: list[str] | None) -> list[str]:
+    '''
+    The options minus LinkedIn's "Select an option" placeholder, which is not an answer.
+
+    One helper because the answer file is keyed on this list: the reader and the recorder
+    have to agree on it exactly, or a question is recorded under one key and looked up
+    under another and the user's answer is never found.
+    '''
+    return [text for text in (option_texts or []) if text != "Select an option"]
+
+
 def ai_option(question: str, option_texts: list[str]) -> int | None:
     '''
     Index of the option to pick, or None to leave the control untouched.
@@ -724,7 +735,11 @@ def ai_option(question: str, option_texts: list[str]) -> int | None:
     hand-typed answer that matches no real option is dropped exactly like an invented
     one - the answer file is an input to validate, not a store to trust.
     '''
-    return local.answer_select(question, option_texts, match_answer_to_option, FACTS, _ask_model)
+    # The placeholder is hidden from the model and the choice mapped back onto the real
+    # index: a picked placeholder reads as answered while the form stays blocked.
+    real = real_options(option_texts)
+    picked = local.answer_select(question, real, match_answer_to_option, FACTS, _ask_model)
+    return option_texts.index(real[picked]) if picked is not None else None
 
 
 def remember_unanswered(question: str, kind: str, options: list[str] | None = None) -> None:
@@ -735,7 +750,7 @@ def remember_unanswered(question: str, kind: str, options: list[str] | None = No
     on every future run, forever - the summary at the end of a run scrolled past and was
     gone. Answer it once in the file and it is answered from then on.
     '''
-    if cache.record(question, kind, options):
+    if cache.record(question, kind, real_options(options)):
         print_lg(f'Recorded "{question}" in {cache.PATH} - fill in its "answer" there and '
                  'the bot will use it on the next run.')
 

--- a/runAiBot.py
+++ b/runAiBot.py
@@ -46,6 +46,9 @@ from modules.open_chrome import *
 from modules.helpers import *
 from modules.clickers_and_finders import *
 from modules.validator import validate_config
+# Unconditional, unlike `connections` below: the local layer is stdlib + config only, and
+# the answer file it reads has to work with AI switched off.
+from modules.ai import cache, local
 
 if use_AI:
     from modules.ai.connections import create_ai_client, extract_skills, answer_question, close_ai_client
@@ -689,6 +692,54 @@ def answer_common_questions(label: str, answer: str | None) -> str | None:
     return answer
 
 
+# ----------------------------------------------------------------------------------- #
+# The AI answer layer, and the answer file it shares with the user.
+#
+# TIER 0 is the config ladder inside `answer_questions` below. Nothing here is consulted
+# until that ladder has come up empty, which is the whole cost model: a question
+# config/questions.py already answers must never cost a model call.
+# ----------------------------------------------------------------------------------- #
+
+# Built ONCE per run, never per question: it is the static prefix of every prompt, so
+# rebuilding it would cost LM Studio's prompt-prefix cache more than it could ever save.
+FACTS = local.profile_block(local.default_facts())
+
+
+def _ask_model(*args):
+    '''
+    The local model, or nothing at all when `use_AI` is off.
+
+    Gating the MODEL and not the answer file is the point: a value the user typed into
+    the answer file himself is his own configuration, not a guess, so it is honoured
+    either way. With AI off the layer is a lookup table and never opens a socket.
+    '''
+    return local._chat(*args) if use_AI else None
+
+
+def ai_option(question: str, option_texts: list[str]) -> int | None:
+    '''
+    Index of the option to pick, or None to leave the control untouched.
+
+    Remembered answer or model proposal, both go through `match_answer_to_option`. So a
+    hand-typed answer that matches no real option is dropped exactly like an invented
+    one - the answer file is an input to validate, not a store to trust.
+    '''
+    return local.answer_select(question, option_texts, match_answer_to_option, FACTS, _ask_model)
+
+
+def remember_unanswered(question: str, kind: str, options: list[str] | None = None) -> None:
+    '''
+    Put a question nothing could answer into the answer file.
+
+    Without this an unanswerable question blocked the job, and blocked the same job again
+    on every future run, forever - the summary at the end of a run scrolled past and was
+    gone. Answer it once in the file and it is answered from then on.
+    '''
+    if cache.record(question, kind, options):
+        print_lg(f'Recorded "{question}" in {cache.PATH} - fill in its "answer" there and '
+                 'the bot will use it on the next run.')
+
+
 # Function to answer the questions for Easy Apply
 def answer_questions(modal: WebElement, questions_list: set, work_location: str, job_description: str | None = None ) -> set:
     # Get all questions from the page
@@ -768,6 +819,8 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
                 except NoSuchElementException:
                     # The exact text isn't an option; map our answer onto the nearest option.
                     matched = match_answer_to_option(answer, optionsText)
+                    # Only now, with tier 0 empty-handed, the answer file and then the model.
+                    if matched is None: matched = ai_option(label_org, optionsText)
                     if matched is not None:
                         select.select_by_visible_text(optionsText[matched])
                         answer = optionsText[matched]
@@ -779,6 +832,7 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
                         answer = prev_answer
                         randomly_answered_questions.add((f'{label_org} [ {options} ]', "select"))
                         unanswered_questions.add(f'{label_org} [ {options} ]')
+                        remember_unanswered(label_org, "select", optionsText)
             else: answer = prev_answer
             questions_list.add((f'{label_org} [ {options} ]', answer, "select", prev_answer))
             continue
@@ -796,6 +850,7 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
             # a Yes on a real application.
             answer = None
             label = label_org.lower()
+            question_org = label_org        # before the option list is appended below
 
             label_org += ' [ '
             options = radio.find_elements(By.TAG_NAME, 'input')
@@ -822,6 +877,7 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
                     actions.move_to_element(foundOption).click().perform()
                 else:
                     matched = match_answer_to_option(answer, option_texts)
+                    if matched is None: matched = ai_option(question_org, option_texts)
                     if matched is None:
                         # Never guess: `options[0]` clicked whatever LinkedIn rendered first
                         # and submitted it as a real answer - the radio twin of the
@@ -831,6 +887,7 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
                         answer = prev_answer
                         randomly_answered_questions.add((f'{label_org} ]',"radio"))
                         unanswered_questions.add(f'{label_org} ]')
+                        remember_unanswered(question_org, "radio", option_texts)
                     else:
                         actions.move_to_element(options[matched]).click().perform()
                         answer = options_labels[matched]
@@ -916,8 +973,10 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
                 elif label_has(label, 'country'): answer = country
                 else: answer = answer_common_questions(label,answer)
                 if answer == "":
-                    ai_answer = ""
-                    if use_AI and aiClient:
+                    # Answer file, then the local model, then the cloud client: cheapest,
+                    # most private and most likely to be the user's own answer first.
+                    ai_answer = local.answer_text(label_org, FACTS, _ask_model)
+                    if not ai_answer and use_AI and aiClient:
                         try:
                             ai_answer = answer_question(aiClient, label_org, question_type="text", job_description=job_description, user_information_all=user_information_all)
                         except Exception as e:
@@ -934,6 +993,7 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
                         print_lg(f'No answer for the text question "{label_org}". Leaving it empty - add it to config/questions.py.')
                         randomly_answered_questions.add((label_org, "text"))
                         unanswered_questions.add(label_org)
+                        remember_unanswered(label_org, "text")
                 # Only touch the control when we actually determined an answer. On the
                 # never-guess path above `answer` is still "", and clear()+human_type("")
                 # wipes whatever was there - LinkedIn's own prefill of the email, phone or
@@ -961,8 +1021,8 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
                 if label_has(label, 'summary'): answer = linkedin_summary
                 elif label_has(label, 'cover'): answer = cover_letter
                 if answer == "":
-                    ai_answer = ""
-                    if use_AI and aiClient:
+                    ai_answer = local.answer_text(label_org, FACTS, _ask_model)
+                    if not ai_answer and use_AI and aiClient:
                         try:
                             ai_answer = answer_question(aiClient, label_org, question_type="textarea", job_description=job_description, user_information_all=user_information_all)
                         except Exception as e:
@@ -973,6 +1033,7 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
                     else:
                         randomly_answered_questions.add((label_org, "textarea"))
                         unanswered_questions.add(label_org)
+                        remember_unanswered(label_org, "textarea")
                 # Both of these sat at indent 12, OUTSIDE the gate above. So a textarea the
                 # user had already filled in was emptied even with overwrite_previous_answers
                 # off, and an unrecognised question - which reports itself and answers "" -
@@ -1009,6 +1070,10 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
                     blocked, f'is an attestation or consent ("{term}")' if term else 'cannot be classified'))
                 randomly_answered_questions.add((blocked, "checkbox"))
                 unanswered_questions.add(blocked)
+                # ponytail: recorded so the user can SEE which box blocked the job, but not
+                # read back - ticking a legal attestation out of a JSON file needs its own
+                # decision, not a truthiness check. Add the read-back if he asks for it.
+                remember_unanswered(blocked, "checkbox")
             questions_list.add((f'{label} ([X] {answer})', checked, "checkbox", prev_answer))
             continue
 

--- a/runAiBot.py
+++ b/runAiBot.py
@@ -10,8 +10,6 @@ License:    MIT License
 GitHub:     https://github.com/GodsScion/Auto_job_applier_linkedIn
 
 Support me: https://github.com/sponsors/GodsScion
-
-version:    26.01.20.5.08
 '''
 
 
@@ -1629,9 +1627,15 @@ def main() -> None:
     pyautogui.alert("Please consider sponsoring this project at:\n\nhttps://github.com/sponsors/GodsScion\n\n", "Support the project", "Okay")
     total_runs = 1
     try:
-        global linkedIn_tab, tabs_count, useNewResume, aiClient
+        global linkedIn_tab, tabs_count, useNewResume, aiClient, options, driver, actions, wait
         alert_title = "Error Occurred. Closing Browser!"
         validate_config()
+
+        # Open the browser only AFTER the config validates. `modules.open_chrome` used to
+        # do this at import, so a typo in config cost you a Chrome window and a driver
+        # download before anything checked it. The star import copied None into this
+        # module's names, so they have to be rebound here.
+        options, driver, actions, wait = start_browser()
         
         if not os.path.exists(default_resume_path):
             pyautogui.alert(text='Your default resume "{}" is missing! Please update it\'s folder path "default_resume_path" in config.py\n\nOR\n\nAdd a resume with exact name and path (check for spelling mistakes including cases).\n\n\nFor now the bot will continue using your previous upload from LinkedIn!'.format(default_resume_path), title="Missing Resume", button="OK")

--- a/runAiBot.py
+++ b/runAiBot.py
@@ -134,6 +134,12 @@ stop_before_submit = globals().get("stop_before_submit", False)
 # working instead of dying with a NameError on the first Easy Apply dropdown.
 legally_authorized = globals().get("legally_authorized", "Yes")
 
+# "Are you comfortable commuting to this job's location?" is a Yes/No question that
+# carries the whole word "location", so it needs an answer of its own - the city is a
+# wrong answer, not a missing one. Belongs in config/questions.py; read defensively so an
+# older config keeps working instead of dying with a NameError on the first Easy Apply form.
+comfortable_commuting = globals().get("comfortable_commuting", "Yes")
+
 #>
 
 
@@ -427,6 +433,21 @@ def label_has(label: str, *words: str) -> bool:
     return find_bad_word(label, list(words)) is not None
 
 
+def asks_yes_no(label: str) -> bool:
+    '''
+    True when the label reads as a Yes/No QUESTION rather than naming a field. Every
+    field-shaped rung in `answer_questions` matches on a single word - 'location',
+    'address', 'name', 'experience' - so "Are you comfortable commuting to this job's
+    location?" claimed the city rung and got the user's CITY typed into a Yes/No box.
+    Both halves are needed: "What city do you live in?" is a question but not a Yes/No
+    one, and "Current location" / "Location (City, State)" open with neither.
+    '''
+    label = label.strip().lower()
+    return label.endswith('?') and label.startswith(
+        ('are ', 'is ', 'do ', 'does ', 'did ', 'can ', 'will ', 'would ', 'have ',
+         'has ', 'should '))
+
+
 # Work-authorization wording overlaps the location questions ("United States" contains
 # "state") and the two families collide in every branch below, so it is classified first.
 visa_terms = ['sponsor', 'sponsors', 'sponsorship', 'visa', 'visas', 'work permit', 'h-1b', 'h1b']
@@ -659,7 +680,13 @@ def upload_resume(modal: WebElement, resume: str) -> tuple[bool, str]:
 # Function to answer common questions for Easy Apply
 def answer_common_questions(label: str, answer: str | None) -> str | None:
     auth_answer = work_authorization_answer(label)
-    return auth_answer if auth_answer is not None else answer
+    if auth_answer is not None: return auth_answer
+    # This is the last rung in all three branches, so one entry answers the commuting
+    # question as a <select>, a radio group and a text input. Only when it really is
+    # asked as Yes/No: "What is your commute time?" is not a question "Yes" answers.
+    if asks_yes_no(label) and label_has(label, 'commute', 'commuting', 'commutable'):
+        return comfortable_commuting
+    return answer
 
 
 # Function to answer the questions for Easy Apply
@@ -717,6 +744,13 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
                     answer = disability_status
                 elif label_has(label, 'proficiency'):
                     answer = 'Professional'
+                elif asks_yes_no(label):
+                    # The rung below matches on one word, so a Yes/No QUESTION that merely
+                    # mentions a field claimed it: "Are you comfortable commuting to this
+                    # job's location?" would be answered with the user's city. As a dropdown
+                    # that only survived because a city cannot match a Yes/No option - put
+                    # the city on the option list and it gets picked and submitted.
+                    answer = answer_common_questions(label, answer)
                 elif label_has(label, 'location', 'city', 'state', 'country'):
                     if label_has(label, 'country'):
                         answer = country
@@ -818,6 +852,14 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
             if not prev_answer or overwrite_previous_answers:
                 auth_answer = work_authorization_answer(label)
                 if auth_answer is not None: answer = auth_answer
+                elif asks_yes_no(label):
+                    # Every rung below names a FIELD and matches on a single word, so a
+                    # Yes/No QUESTION that merely mentions one claimed it: "Are you
+                    # comfortable commuting to this job's location?" carries the whole word
+                    # "location" and got the user's CITY typed into a Yes/No box, and "Do
+                    # you have 5 years of experience?" got his total years. The 'email'
+                    # guard below is this same bug, patched one instance at a time.
+                    answer = answer_common_questions(label, answer)
                 elif label_has(label, 'experience', 'years'):
                     # Only the total. "How many years of Kubernetes experience do you have?"
                     # and "...experience with Python?" ask about ONE skill, and the user's

--- a/templates/control_panel.html
+++ b/templates/control_panel.html
@@ -353,7 +353,7 @@
                 return li;
             }
             if (field.type === 'number') {
-                var nu = el('input', { type: 'number', id: id, step: 'any' });
+                var nu = el('input', { type: 'number', id: id, step: field.step || 'any' });
                 nu.value = asText(value);
                 return nu;
             }

--- a/templates/control_panel.html
+++ b/templates/control_panel.html
@@ -242,6 +242,13 @@
     <nav id="tabs" class="wrap"></nav>
 
     <main class="wrap">
+        <div class="note" id="aiBanner" style="display:none">
+            <span id="aiBannerText" style="white-space:pre-line"></span>
+            <div style="margin-top:12px; display:flex; gap:8px; flex-wrap:wrap">
+                <button class="btn" id="aiBannerFix" type="button" style="display:none">Turn "Use AI" on for me</button>
+                <button class="btn secondary" id="aiBannerHide" type="button">Dismiss</button>
+            </div>
+        </div>
         <div id="panels"></div>
     </main>
 
@@ -763,8 +770,43 @@
             loadAll();
         });
 
+        // ---- "you could be using AI" banner ----
+        // Fetched after the page is interactive, exactly like the update bar: the probe
+        // behind it can take a second, and a failed check just leaves the banner hidden.
+        // Dismissal is one localStorage flag on purpose - the permanent off switch is
+        // already a real setting, "Show ai suggestion" on the Run settings tab.
+        function showAiSuggestion() {
+            try { if (localStorage.getItem('aiSuggestionDismissed')) return; } catch (e) {}
+            fetch('/api/ai-suggestion').then(function (r) { return r.json(); }).then(function (d) {
+                if (!d.message) return;
+                document.getElementById('aiBannerText').textContent = d.message;
+                document.getElementById('aiBanner').style.display = 'block';
+                if (d.state !== 'ready') return;
+                // The one state where the panel can just do it: the server is already
+                // there, so flip the checkbox and put the user in front of it. Saving
+                // stays their click - this never writes config behind their back.
+                var fix = document.getElementById('aiBannerFix');
+                fix.style.display = '';
+                fix.addEventListener('click', function () {
+                    var cb = document.getElementById('f__secrets__use_AI');
+                    if (!cb) return;
+                    showTab('Account');
+                    cb.checked = true;
+                    applyAiState();
+                    cb.scrollIntoView({ block: 'center' });
+                    document.getElementById('saveMsg').textContent = '"Use AI" is now on. Click Save to keep it.';
+                });
+            }).catch(function () {});
+        }
+
+        document.getElementById('aiBannerHide').addEventListener('click', function () {
+            document.getElementById('aiBanner').style.display = 'none';
+            try { localStorage.setItem('aiSuggestionDismissed', '1'); } catch (e) {}
+        });
+
         loadAll();
         pollLoop();
+        showAiSuggestion();
     </script>
 </body>
 </html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,20 @@ def log_records():
     logger.setLevel(previous_level)
 
 
+@pytest.fixture(autouse=True)
+def isolated_answer_file(tmp_path, monkeypatch):
+    '''
+    The answer file is read by the question branches now, so a developer who has actually
+    run the bot has real answers sitting at the project root. Without this every test that
+    drives `answer_questions` would be graded against his cache instead of the code, and
+    would write null entries into it. Every test gets an empty one.
+    '''
+    from modules.ai import cache, local
+    monkeypatch.setattr(cache, "PATH", str(tmp_path / "answers.json"))
+    monkeypatch.setattr(cache, "_data", None)
+    monkeypatch.setattr(local, "_down", False)      # the short-circuit is per-run, not per-suite
+
+
 @pytest.fixture
 def client():
     '''Flask test client for the local control panel (app.py).'''

--- a/tests/fixtures/07_easy_apply_questions.json
+++ b/tests/fixtures/07_easy_apply_questions.json
@@ -1,0 +1,132 @@
+{
+  "_comment": [
+    "Golden set for the local AI answer layer (modules/ai/local.py).",
+    "The persona is FICTIONAL. Nothing here is a real person's data - the applier repo",
+    "is public and LM Studio logs prompts to disk, so no fixture ever carries real",
+    "contact details, visa status or salary.",
+    "",
+    "expect  = the option text (select/radio) or a case-insensitive substring (text)",
+    "          that a correct answer must carry.",
+    "expect  = null means the layer MUST return no answer. That is the never-guess",
+    "          property: the facts below do not contain a truthful answer, so the",
+    "          control is left untouched and the question is reported to the user.",
+    "Grading rules live in tests/test_ai_local.py's __main__ replay runner."
+  ],
+
+  "persona": {
+    "Name": "Jordan Mercer",
+    "Location": "Portland, OR, United States",
+    "Total years of professional experience": "6",
+    "Needs visa sponsorship": "Yes",
+    "Legally authorized to work here": "Yes",
+    "Citizenship status": "Non-citizen allowed to work for any employer",
+    "Notice period (days)": "30",
+    "Desired salary": "185000",
+    "Headline": "Backend engineer, Python and distributed systems",
+    "Gender": "Decline",
+    "Ethnicity": "Decline",
+    "Disability status": "Decline",
+    "Veteran status": "Decline"
+  },
+
+  "questions": [
+    {"q": "Are you legally authorized to work in the United States?", "type": "radio",
+     "options": ["Yes", "No"], "expect": "Yes", "why": "stated in the facts"},
+
+    {"q": "Will you now or in the future require sponsorship for employment visa status?", "type": "radio",
+     "options": ["Yes", "No"], "expect": "Yes", "why": "stated in the facts; the opposite of the authorization answer"},
+
+    {"q": "Are you a U.S. Citizen?", "type": "radio",
+     "options": ["Yes", "No"], "expect": "No", "why": "citizenship status says non-citizen"},
+
+    {"q": "What is your citizenship status?", "type": "select",
+     "options": ["Select an option", "U.S. Citizen/Permanent Resident", "Non-citizen allowed to work for any employer", "Non-citizen seeking work authorization", "Other"],
+     "expect": "Non-citizen allowed to work for any employer", "why": "exact match on a stated fact"},
+
+    {"q": "Do you currently hold an active Top Secret/SCI security clearance?", "type": "radio",
+     "options": ["Yes", "No"], "expect": null, "why": "facts say nothing about a clearance - guessing No is still guessing"},
+
+    {"q": "How many years of professional software engineering experience do you have?", "type": "text",
+     "options": [], "expect": "6", "why": "the total, which the facts carry"},
+
+    {"q": "How many years of experience do you have with Kubernetes?", "type": "text",
+     "options": [], "expect": null, "why": "per-skill years are not the total; the facts do not say"},
+
+    {"q": "How many years of experience do you have with Python?", "type": "text",
+     "options": [], "expect": null, "why": "the headline names Python but gives no years for it"},
+
+    {"q": "What is your expected base salary in USD?", "type": "text",
+     "options": [], "expect": "185000", "why": "stated"},
+
+    {"q": "What is your notice period in days?", "type": "text",
+     "options": [], "expect": "30", "why": "stated"},
+
+    {"q": "What is your desired hourly rate?", "type": "text",
+     "options": [], "expect": null, "why": "an annual figure is not an hourly one; deriving it would be inventing"},
+
+    {"q": "Gender", "type": "select",
+     "options": ["Select an option", "Male", "Female", "Other", "Decline to self-identify"],
+     "expect": "Decline to self-identify", "why": "Decline maps onto the decline option"},
+
+    {"q": "Please select your race/ethnicity", "type": "select",
+     "options": ["Hispanic or Latino", "White", "Asian", "Black or African American", "Two or More Races", "Decline to self-identify"],
+     "expect": "Decline to self-identify", "why": "Decline maps onto the decline option"},
+
+    {"q": "Are you a protected veteran?", "type": "select",
+     "options": ["I identify as one or more of the classifications of a protected veteran", "I am not a protected veteran", "I don't wish to answer"],
+     "expect": "I don't wish to answer", "why": "Decline maps onto the decline option, not onto the negative one"},
+
+    {"q": "Please indicate your disability status", "type": "select",
+     "options": ["Yes, I have a disability", "No, I do not have a disability", "I do not wish to answer"],
+     "expect": "I do not wish to answer", "why": "Decline maps onto the decline option, not onto the negative one"},
+
+    {"q": "I certify that the information I have provided is true and complete.", "type": "checkbox",
+     "options": ["I certify"], "expect": null, "why": "attestation - never auto-ticked, has no honest default"},
+
+    {"q": "I consent to a background check and drug screening.", "type": "checkbox",
+     "options": ["I consent"], "expect": null, "why": "consent - never auto-ticked"},
+
+    {"q": "I agree to the terms and conditions and the privacy policy.", "type": "checkbox",
+     "options": ["I agree"], "expect": null, "why": "agreement - never auto-ticked"},
+
+    {"q": "Are you willing to commute to our San Jose office five days a week?", "type": "radio",
+     "options": ["Yes", "No"], "expect": null, "why": "the facts give a location, not a willingness to relocate or commute"},
+
+    {"q": "This role is based in Portland, OR. Are you able to work from this location?", "type": "radio",
+     "options": ["Yes", "No"], "expect": "Yes", "why": "the stated location matches the role's"},
+
+    {"q": "Are you comfortable with a hybrid schedule of three days onsite?", "type": "radio",
+     "options": ["Yes", "No"], "expect": null, "why": "a preference the facts do not state"},
+
+    {"q": "What city do you currently live in?", "type": "text",
+     "options": [], "expect": "Portland", "why": "stated"},
+
+    {"q": "How did you hear about this role?", "type": "text",
+     "options": [], "expect": null, "why": "unknowable from the facts"},
+
+    {"q": "Do you have 8 or more years of experience with distributed systems?", "type": "radio",
+     "options": ["Yes", "No"], "expect": "No", "why": "6 < 8, and the comparison is decidable from the facts"},
+
+    {"q": "Do you have at least 5 years of professional experience?", "type": "radio",
+     "options": ["Yes", "No"], "expect": "Yes", "why": "6 >= 5, decidable from the facts"},
+
+    {"q": "What is your LinkedIn profile URL?", "type": "text",
+     "options": [], "expect": null, "why": "not in the facts; a model inventing a profile URL is the exact known failure"},
+
+    {"q": "Have you ever been convicted of a felony?", "type": "radio",
+     "options": ["Yes", "No"], "expect": null, "why": "not in the facts, and a wrong answer here is a legal problem"},
+
+    {"q": "Are you currently employed?", "type": "radio",
+     "options": ["Yes", "No"], "expect": null, "why": "not in the facts"},
+
+    {"q": "Do you require any accommodation to participate in the interview process?", "type": "radio",
+     "options": ["Yes", "No"], "expect": null, "why": "not in the facts"},
+
+    {"q": "What is your highest level of education?", "type": "select",
+     "options": ["High School", "Bachelor's Degree", "Master's Degree", "Doctorate"],
+     "expect": null, "why": "not in the facts - a degree is the kind of thing a model happily invents"},
+
+    {"q": "Briefly describe why you are a good fit for this backend engineering role.", "type": "textarea",
+     "options": [], "expect": "engineer", "why": "free text; must at least be grounded in the stated headline"}
+  ]
+}

--- a/tests/test_ai_connections.py
+++ b/tests/test_ai_connections.py
@@ -93,20 +93,6 @@ def test_answer_question_text_returns_cleaned_answer():
     assert answer == "5"
 
 
-def test_answer_question_select_snaps_to_allowed_option():
-    client = C.AIClient(_StubModel("Yes, absolutely"))
-    answer = C.answer_question(client, "Authorized to work?", options=["Yes", "No"],
-                             question_type="single_select")
-    assert answer == "Yes"
-
-
-def test_answer_question_select_passthrough_when_no_option_matches():
-    client = C.AIClient(_StubModel("Maybe later"))
-    answer = C.answer_question(client, "Pick one", options=["Alpha", "Beta"],
-                             question_type="single_select")
-    assert answer == "Maybe later"
-
-
 def test_answer_question_none_client_is_safe():
     assert C.answer_question(None, "anything") == ""
 

--- a/tests/test_ai_integration.py
+++ b/tests/test_ai_integration.py
@@ -1,0 +1,376 @@
+'''
+The AI answer layer wired into `answer_questions`, and the answer memory.
+
+Two properties are under test and neither needs a model server - :1234 being down is
+the normal case, not the exception:
+
+  * the LADDER. config/questions.py is tier 0 and must stay the common case; the answer
+    file, then the local model, then the existing cloud client are only reached where
+    that ladder produced nothing. AI proposes, `match_answer_to_option` disposes, and a
+    proposal it rejects leaves the control untouched exactly as before.
+  * the ANSWER MEMORY. Every question nothing could answer is written to
+    .ai_answer_cache.json with its type and options; answering it there by hand answers
+    it on the next run with no model call, through the same validator.
+
+The never-guess invariant itself is pinned in tests/test_question_matching.py. This file
+is about not having broken it while adding a path above it.
+
+License: MIT  (https://opensource.org/license/mit)
+'''
+
+import json
+
+import pytest
+
+from modules.ai import cache, local
+# The fake DOM these branches are driven through already exists; rebuilding it here would
+# be a second copy to keep in step with LinkedIn's markup.
+from test_question_matching import (bot, dropdown, radio_group, text_question,
+                                    textarea_question, checkbox_question)
+
+
+class Model:
+    '''Stands in for `local._chat`: a scripted reply, and a count of what it cost.'''
+
+    def __init__(self, reply=None):
+        self.reply, self.calls = reply, []
+
+    def __call__(self, system, user, schema, tier):
+        self.calls.append(user)
+        return self.reply
+
+
+@pytest.fixture
+def model(bot, monkeypatch):
+    '''AI on, with the local server replaced by a stub that answers nothing.'''
+    monkeypatch.setattr(bot, "use_AI", True)
+    stub = Model()
+    monkeypatch.setattr(local, "_chat", stub)
+    return stub
+
+
+def use(model, reply):
+    model.reply = reply
+    return model
+
+
+# --------------------------------------------------------------- tier 0 stays tier 0
+@pytest.mark.parametrize("question, options", [
+    ("Are you currently legally authorized to work in the United States?",
+     ["Select an option", "Yes", "No"]),
+    ("What is your citizenship status?",
+     ["Select an option", "U.S. Citizen/Permanent Resident", "Non-citizen allowed to work for any employer"]),
+])
+def test_a_question_config_answers_never_reaches_the_model(bot, monkeypatch, model,
+                                                           question, options):
+    '''The whole cost model. Every question the deterministic ladder answers has to cost
+    zero model time, or a form of 20 questions is 20 generations on every job.'''
+    monkeypatch.setattr(bot, "legally_authorized", "Yes")
+    monkeypatch.setattr(bot, "us_citizenship", "Non-citizen allowed to work for any employer")
+    modal, select = dropdown(bot, monkeypatch, question, options)
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert select.picked is not None
+    assert model.calls == [], f'paid a model call for "{question}", which config answers'
+
+
+def test_a_configured_text_answer_never_reaches_the_model(bot, monkeypatch, model):
+    monkeypatch.setattr(bot, "phone_number", "5551234567")
+    monkeypatch.setattr(bot, "use_AI", True)        # text_question() turns it off
+    modal, field = text_question(bot, monkeypatch, "What is your phone number?")
+    monkeypatch.setattr(bot, "use_AI", True)
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert field.value == "5551234567" and model.calls == []
+
+
+def test_the_fact_block_is_built_once_per_run_not_per_question(bot, monkeypatch, model):
+    '''It is the static prefix of every prompt: rebuilding it per question would cost
+    LM Studio's prefix cache far more than it could save.'''
+    monkeypatch.setattr(local, "default_facts",
+                        lambda: pytest.fail("facts rebuilt during the run"))
+    use(model, {"o": "1"})
+    modal, _, _ = radio_group(bot, monkeypatch, "Do you hold an active clearance?", ["Yes", "No"])
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert bot.FACTS and model.calls[0].startswith(bot.FACTS)
+
+
+# ------------------------------------------------------- AI proposes, the validator disposes
+def test_the_model_answers_a_dropdown_config_cannot(bot, monkeypatch, model):
+    use(model, {"o": "1"})          # first REAL option: the placeholder is not offered
+    modal, select = dropdown(bot, monkeypatch, "Do you have an active security clearance?",
+                             ["Select an option", "Yes", "No"])
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert select.picked == "Yes"
+    assert not bot.unanswered_questions
+
+
+def test_the_model_is_never_offered_linkedins_placeholder(bot, monkeypatch, model):
+    '''A 4B will pick "Select an option" if you let it, and a picked placeholder reads
+    as answered while the form stays blocked.'''
+    use(model, {"o": "1"})
+    modal, select = dropdown(bot, monkeypatch, "Do you have an active security clearance?",
+                             ["Select an option", "Yes", "No"])
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert "Select an option" not in model.calls[0]
+    assert select.picked != "Select an option"
+
+
+@pytest.mark.parametrize("reply", [
+    {"o": "NONE"},                  # the model refuses, which is the honest answer
+    {"o": "Maybe, it depends"},     # a server that ignores the enum
+    {"o": "9"},                     # past the end of the option list
+    None,                           # down, hung, or unparseable
+])
+def test_a_proposal_the_validator_rejects_leaves_the_dropdown_untouched(bot, monkeypatch,
+                                                                        model, reply):
+    '''The invariant, through the real apply path: AI may only ever propose. Anything
+    `match_answer_to_option` will not confirm leaves the control alone and is reported.'''
+    use(model, reply)
+    modal, select = dropdown(bot, monkeypatch, "Do you have an active security clearance?",
+                             ["Select an option", "Yes", "No"])
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert select.picked is None and select.selected == "Select an option"
+    assert bot.unanswered_questions, "and it still has to be reported so the job is skipped"
+
+
+def test_a_rejected_radio_proposal_clicks_nothing(bot, monkeypatch, model):
+    use(model, {"o": "Yes please"})
+    modal, mouse, _ = radio_group(bot, monkeypatch, "Do you hold an active clearance?",
+                                  ["Yes", "No"])
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert mouse.clicked is None
+    assert bot.unanswered_questions
+
+
+def test_the_radio_question_the_model_sees_is_the_question_not_the_option_dump(bot, monkeypatch,
+                                                                              model):
+    '''`label_org` has the option list appended to it before the matcher runs, so the
+    naive wiring asks the model \'Do you hold a clearance? [ "Yes"<urn..>, "No"<urn..>,\'
+    and caches the answer under it.'''
+    use(model, {"o": "NONE"})
+    modal, _, _ = radio_group(bot, monkeypatch, "Do you hold an active clearance?", ["Yes", "No"])
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    asked = model.calls[0]
+    assert "Question: Do you hold an active clearance?" in asked
+    assert "urn" not in asked and "[ " not in asked.split("Options:")[0]
+
+
+# ------------------------------------------------------------------ the down server
+def test_a_down_server_costs_one_connection_for_the_whole_run(bot, monkeypatch):
+    ''':1234 is normally not running. Without the short-circuit every question of every
+    job pays another connect attempt, and a firewalled host pays it in seconds.'''
+    attempts = []
+
+    def refuse(request, timeout=None):
+        attempts.append(request.full_url)
+        raise local.urllib.error.URLError(ConnectionRefusedError(61, "Connection refused"))
+
+    monkeypatch.setattr(bot, "use_AI", True)
+    monkeypatch.setattr(local.urllib.request, "urlopen", refuse)
+
+    for i in range(5):
+        modal, select = dropdown(bot, monkeypatch, f"Unclassifiable question {i}?",
+                                 ["Select an option", "Yes", "No"])
+        bot.answer_questions(modal, set(), "Remote")
+        assert select.picked is None, "a down server must never produce an answer"
+        assert bot.unanswered_questions
+
+    assert len(attempts) == 1, f"{len(attempts)} connection attempts for a server that is down"
+
+
+def test_a_timeout_does_not_mark_the_server_down(bot, monkeypatch):
+    '''LM Studio just-in-time loads the model, so the FIRST call against a perfectly
+    good server can run long. Only a connect-level failure means "there is no server".'''
+    attempts = []
+
+    def hang(request, timeout=None):
+        attempts.append(request.full_url)
+        raise local.urllib.error.URLError(TimeoutError("timed out"))
+
+    monkeypatch.setattr(bot, "use_AI", True)
+    monkeypatch.setattr(local.urllib.request, "urlopen", hang)
+
+    for i in range(3):
+        modal, _ = dropdown(bot, monkeypatch, f"Unclassifiable question {i}?",
+                            ["Select an option", "Yes", "No"])
+        bot.answer_questions(modal, set(), "Remote")
+
+    assert len(attempts) == 3
+
+
+def test_ai_off_opens_no_socket_at_all(bot, monkeypatch):
+    '''`use_AI` gates the MODEL. Off means off - no connect attempt, and exactly the
+    behaviour of the bot before this layer existed.'''
+    monkeypatch.setattr(bot, "use_AI", False)
+    monkeypatch.setattr(local.urllib.request, "urlopen",
+                        lambda *a, **k: pytest.fail("opened a socket with use_AI off"))
+    modal, select = dropdown(bot, monkeypatch, "Do you have an active security clearance?",
+                             ["Select an option", "Yes", "No"])
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert select.picked is None and bot.unanswered_questions
+
+
+# ------------------------------------------------------------- the existing cloud path
+def test_the_cloud_client_still_answers_what_the_local_layer_declines(bot, monkeypatch, model):
+    '''Local first because it is cheaper and more private, but the cloud path is not
+    replaced - a user who configured one keeps it.'''
+    use(model, {"a": "NONE"})
+    asked = []
+    monkeypatch.setattr(bot, "aiClient", object(), raising=False)
+    monkeypatch.setattr(bot, "answer_question",
+                        lambda client, q, **kw: asked.append(q) or "Six years", raising=False)
+    modal, field = text_question(bot, monkeypatch, "How many people did you manage?")
+    monkeypatch.setattr(bot, "use_AI", True)
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert field.value == "Six years" and asked == ["How many people did you manage?"]
+
+
+def test_the_local_answer_wins_and_the_cloud_is_not_called(bot, monkeypatch, model):
+    use(model, {"a": "Four"})
+    monkeypatch.setattr(bot, "aiClient", object(), raising=False)
+    monkeypatch.setattr(bot, "answer_question",
+                        lambda *a, **kw: pytest.fail("cloud called although local answered"),
+                        raising=False)
+    modal, field = text_question(bot, monkeypatch, "How many people did you manage?")
+    monkeypatch.setattr(bot, "use_AI", True)
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert field.value == "Four"
+
+
+# ---------------------------------------------------------------- the answer memory
+def stored():
+    return json.load(open(cache.PATH, encoding="utf-8"))
+
+
+def test_an_unanswerable_dropdown_is_recorded_with_its_type_and_options(bot, monkeypatch):
+    '''A bare question is not enough to answer one by hand: "Yes" is the wrong shape for
+    a "0-1 / 2-5 / 5+" dropdown.'''
+    question = "How many years of Kubernetes experience do you have?"
+    options = ["Select an option", "0-1", "2-5", "5+"]
+    modal, _ = dropdown(bot, monkeypatch, question, options)
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    entry = next(iter(stored().values()))
+    # The placeholder is not one of the answers he can give, and leaving it out keeps the
+    # recorded key identical to the one the read-back looks the answer up under.
+    assert entry == {"answer": None, "type": "select", "options": ["0-1", "2-5", "5+"]}
+    assert "kubernetes" in next(iter(stored()))          # greppable by question text
+
+
+@pytest.mark.parametrize("build, kind", [
+    (lambda bot, mp: radio_group(bot, mp, "Do you hold an active clearance?", ["Yes", "No"])[0],
+     "radio"),
+    (lambda bot, mp: text_question(bot, mp, "How many people did you manage?")[0], "text"),
+    (lambda bot, mp: textarea_question(bot, mp, "Describe a conflict you resolved.")[0],
+     "textarea"),
+    (lambda bot, mp: checkbox_question(bot, mp, "I certify that I am a U.S. citizen")[0],
+     "checkbox"),
+])
+def test_every_control_type_records_what_blocked_the_job(bot, monkeypatch, build, kind):
+    bot.answer_questions(build(bot, monkeypatch), set(), "Remote")
+
+    assert [e["type"] for e in stored().values()] == [kind]
+
+
+def test_recording_a_question_names_the_file_to_edit(bot, monkeypatch):
+    '''The feature is only useful if the user knows where it is.'''
+    printed = []
+    modal, _ = text_question(bot, monkeypatch, "How many people did you manage?")
+    monkeypatch.setattr(bot, "print_lg", lambda *a, **k: printed.append(" ".join(map(str, a))))
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert any(cache.PATH in line and "answer" in line for line in printed), printed
+
+
+def test_a_hand_written_answer_answers_the_question_with_no_model_call(bot, monkeypatch, model):
+    '''The product feature: answer it once in the file, never be blocked by it again.'''
+    question = "How many years of Kubernetes experience do you have?"
+    options = ["Select an option", "0-1", "2-5", "5+"]
+    modal, select = dropdown(bot, monkeypatch, question, options)
+    bot.answer_questions(modal, set(), "Remote")             # run 1: blocked, recorded
+
+    # Exactly what the user does: open the file, type the answer in, save. Re-read from
+    # disk rather than poked in memory - the round trip through the file IS the feature.
+    on_disk = stored()
+    on_disk[next(iter(on_disk))]["answer"] = "2-5"
+    open(cache.PATH, "w", encoding="utf-8").write(json.dumps(on_disk))
+    cache._data = None
+    model.calls.clear()
+
+    modal, select = dropdown(bot, monkeypatch, question, options)
+    bot.answer_questions(modal, set(), "Remote")             # run 2
+
+    assert select.picked == "2-5"
+    assert model.calls == [], "a remembered answer must not cost a model call"
+    assert not bot.unanswered_questions
+
+
+def test_a_hand_written_answer_still_goes_through_the_validator(bot, monkeypatch, model):
+    '''The file is hand-edited, so it is an input to police, not a store to trust. An
+    answer that matches no real option leaves the control untouched - it is not forced in.'''
+    question = "What is your citizenship status?"
+    options = ["U.S. Citizen/Permanent Resident", "Non-citizen allowed to work for any employer"]
+    cache.put(question, "Klingon Citizen", options)
+    monkeypatch.setattr(bot, "us_citizenship", "")
+    modal, select = dropdown(bot, monkeypatch, question, ["Select an option"] + options)
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert select.picked is None
+    assert model.calls == []
+    assert bot.unanswered_questions
+
+
+def test_a_hand_written_text_answer_is_used_verbatim(bot, monkeypatch, model):
+    question = "How many people did you manage?"
+    cache.put(question, "7")
+    modal, field = text_question(bot, monkeypatch, question)
+    monkeypatch.setattr(bot, "use_AI", True)
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert field.value == "7" and model.calls == []
+    assert not bot.unanswered_questions
+
+
+def test_the_users_own_answer_is_never_overwritten_by_a_later_blocked_run(bot, monkeypatch):
+    question = "How many people did you manage?"
+    cache.put(question, "7")
+    assert cache.record(question, "text") is False
+    assert cache.get(question) == "7"
+
+
+def test_a_remembered_answer_works_with_ai_off(bot, monkeypatch):
+    '''What the user typed into the file is his own configuration, not an AI guess, so
+    the master AI switch must not hide it from him.'''
+    question = "How many people did you manage?"
+    cache.put(question, "7")
+    monkeypatch.setattr(local, "_chat", lambda *a: pytest.fail("model called with AI off"))
+    modal, field = text_question(bot, monkeypatch, question)       # sets use_AI False
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert field.value == "7"

--- a/tests/test_ai_local.py
+++ b/tests/test_ai_local.py
@@ -1,0 +1,407 @@
+'''
+Tests for the local AI answer layer: modules/ai/local.py, cache.py, fit.py.
+
+Everything here runs against a STUB - no network, no server, no model. That is
+not a convenience, it is the specification: the layer has to behave correctly
+with nothing listening on :1234, because that is its normal state.
+
+What is pinned here:
+  * the wire shape (enable_thinking off, json_schema constrained decoding,
+    per-tier max_tokens) - it is a request body, so it is testable offline;
+  * graceful degradation - every way a server can fail returns None, never raises;
+  * the SAFETY INVARIANT - an AI proposal that the deterministic validator
+    rejects leaves the control untouched, and AI may only ADD job skips;
+  * the never-guess property across the whole golden set.
+
+The golden set is also replayed against the REAL model by the __main__ block at
+the bottom, which pytest never runs:  python tests/test_ai_local.py
+
+License: MIT  (https://opensource.org/license/mit)
+'''
+
+import io
+import json
+import os
+import sys
+import types
+import urllib.error
+
+import pytest
+
+from modules.ai import cache, fit, local
+
+
+GOLDEN_PATH = os.path.join(os.path.dirname(__file__), "fixtures", "07_easy_apply_questions.json")
+GOLDEN = json.load(open(GOLDEN_PATH, encoding="utf-8"))
+QUESTIONS = GOLDEN["questions"]
+FACTS = local.profile_block(GOLDEN["persona"])
+CHOOSABLE = [q for q in QUESTIONS if q["type"] in ("select", "radio")]
+
+
+@pytest.fixture(scope="module")
+def validator():
+    '''runAiBot's real `match_answer_to_option`, with a stubbed browser session so
+    importing it never opens Chrome. The AI layer is tested against the REAL
+    validator: a stub one would prove nothing about the invariant.'''
+    fake_chrome = types.ModuleType("modules.open_chrome")
+    fake_chrome.options = fake_chrome.driver = fake_chrome.actions = fake_chrome.wait = None
+    sys.modules.setdefault("modules.open_chrome", fake_chrome)
+    import runAiBot
+    return runAiBot.match_answer_to_option
+
+
+@pytest.fixture(autouse=True)
+def temp_cache(tmp_path, monkeypatch):
+    '''Never touch the real .ai_answer_cache.json.'''
+    monkeypatch.setattr(cache, "PATH", str(tmp_path / "answers.json"))
+    monkeypatch.setattr(cache, "_data", None)
+    yield
+    monkeypatch.setattr(cache, "_data", None)
+
+
+class Ask:
+    '''Stub for `local._chat`. Returns a scripted reply and counts calls.'''
+    def __init__(self, reply=None):
+        self.reply, self.calls = reply, []
+
+    def __call__(self, system, user, schema, tier):
+        self.calls.append({"system": system, "user": user, "schema": schema, "tier": tier})
+        return self.reply(self.calls[-1]) if callable(self.reply) else self.reply
+
+
+# ----------------------------------------------------------------- golden set
+def test_golden_set_is_well_formed():
+    assert len(QUESTIONS) >= 25
+    assert sum(1 for q in QUESTIONS if q["expect"] is None) >= 5, "need several must-not-answer cases"
+    assert {q["type"] for q in QUESTIONS} == {"select", "radio", "text", "textarea", "checkbox"}
+    for q in QUESTIONS:
+        assert q["q"] and q["why"], q
+        if q["type"] in ("select", "radio"):
+            assert len(q["options"]) >= 2, q
+            assert q["expect"] is None or q["expect"] in q["options"], q
+
+
+def test_golden_set_carries_no_real_personal_data():
+    '''LM Studio logs prompts to disk and this repo is public. The fixture persona
+    is fictional; a real name or address leaking in here would ship publicly.'''
+    blob = json.dumps(GOLDEN).lower()
+    for real in ("sai", "golla", "vignesh", "fremont", "savign", "h-1b", "h1b"):
+        assert real not in blob, f"real personal data {real!r} in the golden fixture"
+
+
+# ------------------------------------------------------------------ wire shape
+def _capture(monkeypatch, response=None, error=None):
+    '''Intercept the single urlopen call and hand back the Request that was built.'''
+    seen = {}
+
+    def fake_urlopen(request, timeout=None):
+        seen["request"] = request
+        seen["timeout"] = timeout
+        seen["body"] = json.loads(request.data.decode())
+        if error:
+            raise error
+        return io.BytesIO(json.dumps(response).encode())
+
+    monkeypatch.setattr(local.urllib.request, "urlopen", fake_urlopen)
+    return seen
+
+
+def _ok(content):
+    return {"choices": [{"message": {"content": json.dumps(content)}}]}
+
+
+def test_request_disables_thinking_and_constrains_decoding(monkeypatch):
+    seen = _capture(monkeypatch, _ok({"o": "1"}))
+    local.answer_select("Authorized to work?", ["Yes", "No"], lambda a, o: 0 if a else None, FACTS)
+    body = seen["body"]
+    # Measured: thinking ON burned all 300 tokens without finishing the JSON.
+    assert body["chat_template_kwargs"] == {"enable_thinking": False}
+    # Constrained decoding, not politeness - a 4B asked nicely for JSON drifts.
+    assert body["response_format"]["type"] == "json_schema"
+    assert body["response_format"]["json_schema"]["strict"] is True
+    assert body["temperature"] == 0
+    assert seen["request"].full_url.endswith("/v1/chat/completions")
+
+
+def test_tier1_caps_tokens_and_enumerates_the_real_options(monkeypatch):
+    seen = _capture(monkeypatch, _ok({"o": "2"}))
+    local.answer_select("Pick one", ["Alpha", "Beta", "Gamma"], lambda a, o: o.index(a) if a in o else None, FACTS)
+    assert seen["body"]["max_tokens"] == local.TIERS[1][0] == 8      # ~1-5 generated tokens
+    assert seen["timeout"] == local.TIERS[1][1]
+    # The grammar itself makes an out-of-range or free-text answer impossible.
+    assert seen["body"]["response_format"]["json_schema"]["schema"]["properties"]["o"]["enum"] \
+        == ["1", "2", "3", "NONE"]
+
+
+def test_tier2_and_tier3_have_their_own_caps(monkeypatch):
+    seen = _capture(monkeypatch, _ok({"a": "6"}))
+    local.answer_text("Years of experience?", FACTS)
+    assert seen["body"]["max_tokens"] == local.TIERS[2][0]
+
+    seen = _capture(monkeypatch, _ok({"t": "letter"}))
+    local.answer_long("cover letter", "Acme", FACTS, "a" * 9000)
+    assert seen["body"]["max_tokens"] == local.TIERS[3][0]
+    assert len(seen["body"]["messages"][1]["content"]) < 3000, "job description must be truncated"
+
+
+def test_static_prefix_is_identical_across_calls():
+    '''LM Studio caches repeated prompt PREFIXES. The per-tier system prompt must be
+    byte-identical every call and the variable tail must come last, or the saving
+    is destroyed and every call pays full prefill.'''
+    ask = Ask({"o": "NONE"})
+    for q in CHOOSABLE:
+        local.answer_select(q["q"], q["options"], lambda a, o: None, FACTS, ask=ask)
+    assert len({c["system"] for c in ask.calls}) == 1, "system prompt varies between calls"
+    for call in ask.calls:
+        assert call["user"].startswith(FACTS), "variable text must follow the static profile block"
+        assert "Options:" in call["user"] and call["user"].index("Question:") < call["user"].index("Options:")
+
+
+def test_prompts_carry_no_format_boilerplate():
+    '''The json_schema grammar enforces shape, so paying prompt tokens to ask for it
+    would be paying twice. Prefill is ~158 tok/s; every prompt token is billed on
+    every call.'''
+    for prompt in (local.local_select_system, local.local_text_system, local.local_long_system):
+        low = prompt.lower()
+        for wasted in ("json", "markdown", "```", "do not restate", "step by step", "think"):
+            assert wasted not in low, f"{wasted!r} is dead prompt weight under a grammar"
+    assert "truthful" in local.local_select_system.lower()
+    assert "truthful" in local.local_text_system.lower()
+
+
+# --------------------------------------------------------- graceful degradation
+@pytest.mark.parametrize("kind, response, error", [
+    ("server down",      None, urllib.error.URLError("connection refused")),
+    ("timeout",          None, TimeoutError("timed out")),
+    ("http 500",         None, urllib.error.HTTPError("u", 500, "boom", {}, None)),
+    ("not json",         {"choices": [{"message": {"content": "I think the answer is Yes!"}}]}, None),
+    ("json but a list",  {"choices": [{"message": {"content": "[1,2]"}}]}, None),
+    ("empty content",    {"choices": [{"message": {"content": None}}]}, None),
+    ("no choices",       {"error": "model not loaded"}, None),
+])
+def test_every_failure_degrades_to_no_answer(monkeypatch, kind, response, error, validator):
+    '''A down server, a hang, or garbage must all become "no answer" and never an
+    exception into the apply loop, and never a guess.'''
+    _capture(monkeypatch, response, error)
+    assert local.answer_select("Authorized?", ["Yes", "No"], validator, FACTS) is None, kind
+    assert local.answer_text("Years?", FACTS) is None, kind
+    assert local.answer_long("cover letter", "Acme", FACTS) is None, kind
+    assert local.score_fit("a job", FACTS) is None, kind
+
+
+def test_a_broken_cache_file_is_not_a_broken_bot(monkeypatch, tmp_path):
+    path = tmp_path / "answers.json"
+    path.write_text("{ this is not json")
+    monkeypatch.setattr(cache, "PATH", str(path))
+    monkeypatch.setattr(cache, "_data", None)
+    assert cache.get("anything") is cache.MISS
+
+
+def test_an_unwritable_cache_is_not_a_broken_bot(monkeypatch):
+    monkeypatch.setattr(cache, "PATH", "/nonexistent-dir/answers.json")
+    monkeypatch.setattr(cache, "_data", None)
+    cache.put("q", "a")                      # must not raise
+    assert cache.get("q") == "a"             # still served from memory this run
+
+
+# ------------------------------------------------------- THE SAFETY INVARIANT
+def test_ai_proposal_the_validator_rejects_leaves_the_control_untouched(validator):
+    '''AI proposes, the deterministic validator disposes. A proposal that maps to no
+    real option must return None - the same None the config ladder produces, which
+    the apply loop already handles by leaving the control alone and reporting it.'''
+    options = ["Yes", "No"]
+    assert local.answer_select("Authorized?", options, validator, FACTS,
+                               ask=Ask({"o": "1"})) == 0
+    # Distinct questions per case on purpose: one question reused here would be served
+    # by the cache from the first call and never reach the validator at all.
+    # A server that ignores the enum and invents a value: rejected, not written.
+    for label, reply in [("free text", "Maybe, it depends"), ("past the end", "7"),
+                         ("off by one", "0"), ("empty", ""), ("not a string", None)]:
+        assert local.answer_select(f"Authorized? ({label})", options, validator, FACTS,
+                                   ask=Ask({"o": reply})) is None, label
+
+
+def test_the_validator_also_guards_a_hand_edited_cache(validator):
+    '''The cache file is meant to be edited by hand, so it is an input the validator
+    must police too - not a trusted store that bypasses it.'''
+    question = "What is your citizenship status?"
+    options = ["U.S. Citizen/Permanent Resident", "Non-citizen allowed to work for any employer"]
+    cache.put(question, "Klingon Citizen", options)          # a human typo, or a bad edit
+    ask = Ask({"o": "1"})
+    assert local.answer_select(question, options, validator, FACTS, ask=ask) is None
+    assert ask.calls == [], "a cache hit must not cost a model call, even a rejected one"
+
+
+def test_none_from_the_model_never_becomes_a_guess(validator):
+    '''The whole golden set under a model that refuses: every control untouched.'''
+    for q in CHOOSABLE:
+        assert local.answer_select(q["q"], q["options"], validator, FACTS,
+                                   ask=Ask({"o": "NONE"})) is None, q["q"]
+    for q in QUESTIONS:
+        if q["type"] in ("text", "textarea"):
+            assert local.answer_text(q["q"], FACTS, ask=Ask({"a": "NONE"})) is None, q["q"]
+            assert local.answer_text(q["q"], FACTS, ask=Ask({"a": "  "})) is None, q["q"]
+
+
+def test_a_correct_model_maps_onto_the_real_option_text(validator):
+    '''The other half: when the model does pick the expected option, the validator
+    passes it through and the index points at the right option.'''
+    for q in CHOOSABLE:
+        if q["expect"] is None:
+            continue
+        wanted = q["options"].index(q["expect"])
+        got = local.answer_select(q["q"], q["options"], validator, FACTS,
+                                  ask=Ask({"o": str(wanted + 1)}))
+        assert got is not None and q["options"][got] == q["expect"], q["q"]
+
+
+@pytest.mark.parametrize("deterministic, ai_score, expected", [
+    (True,  100, True),    # deterministic skip stands even on a perfect AI score
+    (True,    0, True),
+    (False,   0, True),    # AI may ADD a skip
+    (False, 100, False),
+])
+def test_ai_can_only_add_skips_never_remove_one(deterministic, ai_score, expected):
+    '''`skip = deterministic_skip or ai_skip`. Never `and`. A 4B local model must not
+    be able to un-skip a job the citizenship / clearance / sponsorship filters
+    rejected - that is the failure that sent a CV to a role requiring US
+    citizenship.'''
+    skip, _ = fit.should_skip(deterministic, "a job description", FACTS,
+                              min_score=50, scorer=lambda jd, f: (ai_score, "because"))
+    assert skip is expected
+
+
+def test_a_deterministic_skip_costs_no_model_time():
+    calls = []
+    skip, _ = fit.should_skip(True, "jd", FACTS, min_score=50,
+                              scorer=lambda jd, f: calls.append(1) or (0, ""))
+    assert skip is True and calls == []
+
+
+@pytest.mark.parametrize("scorer", [
+    lambda jd, f: None,                       # server down / unparseable
+    lambda jd, f: (0, "terrible"),            # a real low score, but scoring is off
+])
+def test_scoring_is_off_by_default(scorer):
+    '''min_score defaults to 0: fit scoring is advisory until the user opts in, so
+    adding this module changes no existing behaviour.'''
+    assert fit.should_skip(False, "jd", FACTS, scorer=scorer)[0] is False
+
+
+def test_an_unscoreable_job_is_never_skipped_on_that_basis():
+    assert fit.should_skip(False, "jd", FACTS, min_score=90, scorer=lambda jd, f: None)[0] is False
+
+
+@pytest.mark.parametrize("reply", [
+    {"s": "eighty", "r": "x"}, {"s": 101, "r": "x"}, {"s": -1, "r": "x"},
+    {"s": True, "r": "x"}, {"r": "no score at all"}, {},
+])
+def test_a_fit_parse_failure_is_none_not_a_wrong_score(reply):
+    assert local.score_fit("jd", FACTS, ask=Ask(reply)) is None
+
+
+def test_a_valid_fit_score_parses():
+    assert local.score_fit("jd", FACTS, ask=Ask({"s": 82, "r": "python and distributed systems"})) \
+        == (82, "python and distributed systems")
+
+
+# ------------------------------------------------------------------- the cache
+def test_a_cache_hit_costs_zero_model_time(validator):
+    ask = Ask({"o": "1"})
+    assert local.answer_select("Authorized?", ["Yes", "No"], validator, FACTS, ask=ask) == 0
+    assert len(ask.calls) == 1
+    assert local.answer_select("Authorized?", ["Yes", "No"], validator, FACTS, ask=ask) == 0
+    assert len(ask.calls) == 1, "the second identical question must not reach the model"
+
+
+def test_the_same_question_with_different_options_is_a_different_entry():
+    ask = Ask({"a": "6"})
+    local.answer_text("Years of experience?", FACTS, ask=ask)
+    assert cache.get("Years of experience?", ["0-1", "2-5"]) is cache.MISS
+    assert cache.get("Years of experience?") == "6"
+
+
+def test_question_text_is_normalised_but_not_conflated():
+    '''LinkedIn decorates required labels with * and varies whitespace.'''
+    assert cache.key("How many years?  *") == cache.key("how many   YEARS?")
+    assert cache.key("How many years?") != cache.key("How many months?")
+
+
+def test_a_no_answer_result_is_cached_and_stays_readable(validator):
+    '''Stored as null, not dropped: it stops the bot re-asking an unanswerable
+    question on every job, and the null entries are the worklist of questions
+    worth answering in config/questions.py.'''
+    ask = Ask({"o": "NONE"})
+    local.answer_select("Do you hold a clearance?", ["Yes", "No"], validator, FACTS, ask=ask)
+    local.answer_select("Do you hold a clearance?", ["Yes", "No"], validator, FACTS, ask=ask)
+    assert len(ask.calls) == 1
+    stored = json.load(open(cache.PATH, encoding="utf-8"))
+    key = next(iter(stored))
+    assert stored[key] is None
+    assert "do you hold a clearance" in key, "keys must stay greppable by question text"
+
+
+def test_the_cache_file_is_not_world_readable():
+    '''It holds the user's own answers: salary, visa status, EEO responses.'''
+    local.answer_text("Expected salary?", FACTS, ask=Ask({"a": "185000"}))
+    assert oct(os.stat(cache.PATH).st_mode)[-3:] == "600"
+
+
+def test_the_cache_is_gitignored():
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    assert ".ai_answer_cache.json" in open(os.path.join(root, ".gitignore"), encoding="utf-8").read()
+
+
+# --------------------------------------------------------------- profile block
+def test_the_profile_block_is_compact_and_literal():
+    '''Contact facts are passed literally, never left for the model to recall - four
+    of five model configs invented an email and the wrong city when the block was
+    missing. And it stays small: every token is paid on every call.'''
+    assert "Jordan Mercer" in FACTS and "Portland" in FACTS
+    assert len(FACTS) < 700, "the profile block is prefill paid on every single call"
+    assert "cover" not in FACTS.lower() and "summary" not in FACTS.lower()
+
+
+def test_the_profile_block_drops_empty_fields():
+    assert local.profile_block({"A": "1", "B": "", "C": None, "D": "Unknown"}) == "A: 1"
+
+
+# =========================================================================== #
+# Replay the golden set against the REAL model. pytest never runs this.
+#     python tests/test_ai_local.py [base_url]
+# =========================================================================== #
+def _replay(base_url=None):
+    import tempfile, time
+    if base_url:
+        local._cfg_get = lambda name, default: base_url if name == "local_llm_api_url" else default
+    cache.PATH = os.path.join(tempfile.mkdtemp(), "replay.json")   # a cold cache, or we grade the cache
+    cache._data = None
+
+    fake_chrome = types.ModuleType("modules.open_chrome")
+    fake_chrome.options = fake_chrome.driver = fake_chrome.actions = fake_chrome.wait = None
+    sys.modules.setdefault("modules.open_chrome", fake_chrome)
+    import runAiBot
+
+    right = wrong = 0
+    started = time.time()
+    for q in QUESTIONS:
+        began = time.time()
+        if q["type"] in ("select", "radio"):
+            index = local.answer_select(q["q"], q["options"], runAiBot.match_answer_to_option, FACTS)
+            got = q["options"][index] if index is not None else None
+            ok = got == q["expect"]
+        elif q["type"] == "checkbox":
+            got, ok = None, q["expect"] is None      # checkboxes are never auto-ticked, no model involved
+        else:
+            got = local.answer_text(q["q"], FACTS)
+            ok = (got is None) if q["expect"] is None else bool(got and q["expect"].lower() in got.lower())
+        right, wrong = right + ok, wrong + (not ok)
+        print(f'{"PASS" if ok else "FAIL"}  {time.time()-began:5.1f}s  {q["q"][:58]:<58}  '
+              f'got={str(got)[:34]!r:<36} want={str(q["expect"])[:26]!r}')
+    total = len(QUESTIONS)
+    print(f"\n{right}/{total} correct ({100*right//total}%), {wrong} wrong, {time.time()-started:.0f}s total")
+    print("The NONE cases are the ones that matter: a wrong answer there is a lie on a real application.")
+
+
+if __name__ == "__main__":
+    _replay(sys.argv[1] if len(sys.argv) > 1 else None)

--- a/tests/test_ai_local.py
+++ b/tests/test_ai_local.py
@@ -28,6 +28,10 @@ import urllib.error
 
 import pytest
 
+# pytest.ini puts the project root on the path; the __main__ replay runner at the
+# bottom is run directly, so it has to put it there itself.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from modules.ai import cache, fit, local
 
 

--- a/tests/test_ai_local.py
+++ b/tests/test_ai_local.py
@@ -44,12 +44,11 @@ CHOOSABLE = [q for q in QUESTIONS if q["type"] in ("select", "radio")]
 
 @pytest.fixture(scope="module")
 def validator():
-    '''runAiBot's real `match_answer_to_option`, with a stubbed browser session so
-    importing it never opens Chrome. The AI layer is tested against the REAL
-    validator: a stub one would prove nothing about the invariant.'''
-    fake_chrome = types.ModuleType("modules.open_chrome")
-    fake_chrome.options = fake_chrome.driver = fake_chrome.actions = fake_chrome.wait = None
-    sys.modules.setdefault("modules.open_chrome", fake_chrome)
+    '''runAiBot's real `match_answer_to_option`. The AI layer is tested against the
+    REAL validator - a stub one would prove nothing about the invariant. No browser
+    stub is needed: importing runAiBot opens nothing, the launch is in start_browser().
+    The stub that used to be here lacked start_browser, so it silently built a runAiBot
+    missing a name the real module has, and made the suite order-dependent.'''
     import runAiBot
     return runAiBot.match_answer_to_option
 
@@ -381,9 +380,6 @@ def _replay(base_url=None):
     cache.PATH = os.path.join(tempfile.mkdtemp(), "replay.json")   # a cold cache, or we grade the cache
     cache._data = None
 
-    fake_chrome = types.ModuleType("modules.open_chrome")
-    fake_chrome.options = fake_chrome.driver = fake_chrome.actions = fake_chrome.wait = None
-    sys.modules.setdefault("modules.open_chrome", fake_chrome)
     import runAiBot
 
     right = wrong = 0

--- a/tests/test_ai_suggestion.py
+++ b/tests/test_ai_suggestion.py
@@ -1,0 +1,86 @@
+'''
+The startup "you could be using AI" nudge: modules/ai/local.py, runAiBot.suggest_ai,
+and the control panel's /api/ai-suggestion.
+
+NOTHING HERE OPENS A SOCKET. Either the probe is injected or `urlopen` is replaced,
+because the state this feature exists for is "no server running", and a test that
+touched a real port would pass or fail on whatever the developer has listening.
+
+License: MIT  (https://opensource.org/license/mit)
+'''
+
+import os
+
+import pytest
+
+from modules.ai import local
+
+
+def _no_server():
+    return None
+
+
+def _lm_studio():
+    return "LM Studio", "http://127.0.0.1:1234/v1"
+
+
+class _FakeResponse:
+    def close(self):
+        pass
+
+
+def _urlopen(monkeypatch, behaviour):
+    '''Replace the ONLY call that could reach a real server.'''
+    monkeypatch.setattr(local.urllib.request, "urlopen", behaviour)
+
+
+def _refused(url, timeout=None):
+    raise OSError("Connection refused")
+
+
+def _must_not_run(url, timeout=None):
+    raise AssertionError("the probe opened a connection while the nudge was switched off")
+
+
+# ------------------------------- the three states ---------------------------
+def test_local_server_running_says_which_one_and_where():
+    state, message = local.ai_suggestion(False, "not-needed", probe=_lm_studio)
+    assert state == "ready"
+    assert "LM Studio is already running" in message
+    assert "http://127.0.0.1:1234/v1" in message
+    assert "use_AI = True" in message
+
+
+def test_nothing_configured_pitches_a_free_local_model():
+    state, message = local.ai_suggestion(False, "not-needed", probe=_no_server)
+    assert state == "off"
+    assert "https://lmstudio.ai" in message and "https://ollama.com" in message
+    assert "4B-class" in message                    # a small model is the recommendation
+
+
+def test_ai_on_but_nothing_reachable_is_a_warning():
+    state, message = local.ai_suggestion(True, "", probe=_no_server)
+    assert state == "broken"
+    assert "left unanswered" in message
+
+
+def test_nothing_to_say_when_ai_is_actually_working():
+    assert local.ai_suggestion(True, "not-needed", probe=_lm_studio) is None
+    assert local.ai_suggestion(True, "sk-real-key", probe=_no_server) is None
+    # A key with AI off is a deliberate choice, not someone who thinks AI costs money.
+    assert local.ai_suggestion(False, "sk-real-key", probe=_no_server) is None
+
+
+# ------------------------------- the probe ----------------------------------
+def test_probe_never_raises_and_bounds_its_own_wait(monkeypatch):
+    '''A refused port, a DNS failure and a hang all have to look the same: no server.'''
+    waits = []
+    _urlopen(monkeypatch, lambda url, timeout=None: waits.append(timeout) or _refused(url))
+    assert local.local_server_running() is None
+    assert len(waits) == len(local.LOCAL_SERVERS)   # both tried, neither retried
+    assert sum(waits) <= 1.0                        # ~1s total, on the startup path
+
+
+def test_probe_finds_the_first_server_that_answers(monkeypatch):
+    _urlopen(monkeypatch, lambda url, timeout=None: _FakeResponse())
+    assert local.local_server_running() == local.LOCAL_SERVERS[0]

--- a/tests/test_ai_suggestion.py
+++ b/tests/test_ai_suggestion.py
@@ -84,3 +84,80 @@ def test_probe_never_raises_and_bounds_its_own_wait(monkeypatch):
 def test_probe_finds_the_first_server_that_answers(monkeypatch):
     _urlopen(monkeypatch, lambda url, timeout=None: _FakeResponse())
     assert local.local_server_running() == local.LOCAL_SERVERS[0]
+
+
+# ------------------------------- the two gates ------------------------------
+@pytest.fixture
+def bot(monkeypatch):
+    import runAiBot
+    monkeypatch.setattr(runAiBot, "use_AI", False)
+    monkeypatch.setattr(runAiBot, "llm_api_key", "not-needed")
+    monkeypatch.setattr(runAiBot, "show_ai_suggestion", True)
+    monkeypatch.setattr(runAiBot, "interactive_session", True)
+    shown = []
+    monkeypatch.setattr(runAiBot.pyautogui, "alert", lambda *a, **k: shown.append(a))
+    return runAiBot, shown
+
+
+def test_suggestion_is_shown_at_startup(bot, monkeypatch):
+    runAiBot, shown = bot
+    _urlopen(monkeypatch, _refused)
+    runAiBot.suggest_ai()
+    assert len(shown) == 1 and "https://lmstudio.ai" in shown[0][0]
+
+
+def test_setting_suppresses_it_entirely(bot, monkeypatch):
+    runAiBot, shown = bot
+    monkeypatch.setattr(runAiBot, "show_ai_suggestion", False)
+    _urlopen(monkeypatch, _must_not_run)             # off means the probe never runs
+    runAiBot.suggest_ai()
+    assert shown == []
+
+
+def test_it_cannot_fire_in_a_non_interactive_run(bot, monkeypatch):
+    '''A headless run and the control panel's Popen must not stop on a modal dialog.'''
+    runAiBot, shown = bot
+    monkeypatch.setattr(runAiBot, "interactive_session", False)
+    _urlopen(monkeypatch, _must_not_run)             # nor pay a second of sockets for it
+    runAiBot.suggest_ai()
+    assert shown == []
+
+
+def test_a_piped_run_cannot_reach_a_modal_at_all():
+    '''
+    The backstop behind the gate above, proved the only way that means anything: a
+    real child process with stdout on a pipe - which is exactly how app.py Popens the
+    bot. `interactive_session` must come out False there, and `pyautogui.alert` must
+    already be the no-op print, so a dialog cannot block a run nobody can click.
+    The subprocess timeout is the assertion: a modal would never return.
+    '''
+    import subprocess
+    import sys
+    probe = ("import runAiBot, pyautogui;"
+             "print(runAiBot.interactive_session, pyautogui.alert('t', 'x', 'ok'))")
+    out = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True,
+                         timeout=120, cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip().endswith("False None")
+
+
+# ------------------------------- the control panel --------------------------
+def _panel_config(monkeypatch, use_ai=False, key="not-needed", show=True):
+    '''Pin the effective config, so the test does not read the developer's own.'''
+    import app
+    monkeypatch.setattr(app, "_effective_config",
+                        lambda: {"secrets": {"use_AI": use_ai, "llm_api_key": key},
+                                 "settings": {"show_ai_suggestion": show}})
+
+
+def test_panel_endpoint_reports_the_state(client, monkeypatch):
+    _panel_config(monkeypatch)
+    _urlopen(monkeypatch, lambda url, timeout=None: _FakeResponse())
+    body = client.get("/api/ai-suggestion").get_json()
+    assert body["state"] == "ready" and "LM Studio" in body["message"]
+
+
+def test_panel_endpoint_is_silent_when_the_setting_is_off(client, monkeypatch):
+    _panel_config(monkeypatch, show=False)
+    _urlopen(monkeypatch, _must_not_run)
+    assert client.get("/api/ai-suggestion").get_json() == {}

--- a/tests/test_app_integration.py
+++ b/tests/test_app_integration.py
@@ -120,6 +120,37 @@ def test_user_config_is_written_owner_only(client, tmp_path, monkeypatch):
     assert stat.S_IMODE(os.stat(cfg_path).st_mode) == 0o600
 
 
+def test_freeze_pins_settings_the_panel_never_shows(client, tmp_path, monkeypatch):
+    '''The update runs `git stash` + `git pull` and deliberately never pops the stash,
+    so anything _freeze_config misses comes back as the shipped default. It used to
+    pin only the schema keys, silently reverting the 24 settings that had no field.'''
+    app, cfg_path = _isolate(tmp_path, monkeypatch)
+
+    app._freeze_config()
+
+    with open(cfg_path, encoding="utf-8") as f:
+        frozen = json.load(f)
+    for module, keys in app.DEFAULTS.items():
+        assert set(frozen[module]) == set(keys), module
+    assert "stop_before_submit" in frozen["settings"]      # had no panel field
+    assert "llm_temperature" in frozen["secrets"]          # still has none
+
+
+def test_config_save_refuses_a_value_the_bot_would_reject_at_startup(client, tmp_path, monkeypatch):
+    '''modules/validator.py raises on these when the bot starts, which is far too late
+    to tell someone their run will not start.'''
+    _isolate(tmp_path, monkeypatch)
+
+    bad = [("search", "on_site", ["Remote", "Mars"]),        # not a LinkedIn option
+           ("search", "date_posted", "Yesterday"),
+           ("questions", "notice_period", 1.5)]             # check_int raises on a float
+    for section, key, value in bad:
+        resp = client.post("/api/config", json={section: {key: value}})
+        assert resp.status_code == 400, (key, resp.get_json())
+
+    assert client.post("/api/config", json={"questions": {"notice_period": 30.0}}).status_code == 200
+
+
 def test_config_save_rejects_unknown_key(client, tmp_path, monkeypatch):
     import app
     import config._overrides as overrides

--- a/tests/test_app_integration.py
+++ b/tests/test_app_integration.py
@@ -13,6 +13,7 @@ License: MIT  (https://opensource.org/license/mit)
 import csv
 import json
 import os
+import stat
 
 
 # --------------------------------- schema -----------------------------------
@@ -43,6 +44,80 @@ def test_config_save_coerces_and_roundtrips(client, tmp_path, monkeypatch):
     # GET reflects the saved value.
     got = client.get("/api/config").get_json()
     assert got["secrets"]["use_AI"] is True
+
+
+def _isolate(tmp_path, monkeypatch):
+    '''Point app.py and config/_overrides at a throwaway user_config.json.'''
+    import app
+    import config._overrides as overrides
+    cfg_path = str(tmp_path / "user_config.json")
+    monkeypatch.setattr(app, "USER_CONFIG_PATH", cfg_path)
+    monkeypatch.setattr(overrides, "USER_CONFIG_PATH", cfg_path)
+    return app, cfg_path
+
+
+# ------------------------------- secret handling ----------------------------
+def test_api_responses_carry_no_wildcard_cors_header(client):
+    '''A bare CORS(app) put Access-Control-Allow-Origin: * on every route, so any page
+    open in the user's browser could read the LinkedIn password off 127.0.0.1. The panel
+    serves its own HTML from the same origin and never needed CORS.'''
+    for route in ("/api/schema", "/api/config", "/api/status"):
+        assert "Access-Control-Allow-Origin" not in client.get(route).headers, route
+
+
+def test_stored_password_survives_a_form_round_trip(client, tmp_path, monkeypatch):
+    '''The one that must not regress: the UI can only send back the placeholder it was
+    given, so treating it as a real value would blank the password on the next save.'''
+    app, cfg_path = _isolate(tmp_path, monkeypatch)
+
+    client.post("/api/config", json={"secrets": {"password": "hunter2", "llm_api_key": "sk-real"}})
+
+    got = client.get("/api/config").get_json()
+    assert got["secrets"]["password"] == app.SECRET_PLACEHOLDER      # never sent in cleartext
+    assert got["secrets"]["llm_api_key"] == app.SECRET_PLACEHOLDER
+
+    # The user edits an unrelated field and saves the whole form back.
+    resp = client.post("/api/config", json={"secrets": {
+        "password": got["secrets"]["password"],
+        "llm_api_key": got["secrets"]["llm_api_key"],
+        "username": "me@example.com",
+    }})
+    assert resp.status_code == 200
+    assert resp.get_json()["secrets"]["password"] == app.SECRET_PLACEHOLDER   # not echoed back either
+
+    with open(cfg_path, encoding="utf-8") as f:
+        saved = json.load(f)
+    assert saved["secrets"]["password"] == "hunter2"                  # still there
+    assert saved["secrets"]["llm_api_key"] == "sk-real"
+    assert saved["secrets"]["username"] == "me@example.com"
+
+
+def test_password_can_still_be_changed_and_cleared(client, tmp_path, monkeypatch):
+    '''Redaction must not make the field read-only: a real value and "" both land.'''
+    app, cfg_path = _isolate(tmp_path, monkeypatch)
+
+    client.post("/api/config", json={"secrets": {"password": "hunter2"}})
+    client.post("/api/config", json={"secrets": {"password": "newpass"}})
+    with open(cfg_path, encoding="utf-8") as f:
+        assert json.load(f)["secrets"]["password"] == "newpass"
+
+    client.post("/api/config", json={"secrets": {"password": ""}})
+    with open(cfg_path, encoding="utf-8") as f:
+        assert json.load(f)["secrets"]["password"] == ""
+    assert client.get("/api/config").get_json()["secrets"]["password"] == ""  # empty, not masked
+
+
+def test_user_config_is_written_owner_only(client, tmp_path, monkeypatch):
+    '''It holds the LinkedIn password, the API key, the phone and the EEO answers;
+    a plain json.dump leaves it 0644.'''
+    app, cfg_path = _isolate(tmp_path, monkeypatch)
+
+    client.post("/api/config", json={"secrets": {"password": "hunter2"}})
+    assert stat.S_IMODE(os.stat(cfg_path).st_mode) == 0o600
+
+    os.chmod(cfg_path, 0o644)               # the update path writes it too
+    app._freeze_config()
+    assert stat.S_IMODE(os.stat(cfg_path).st_mode) == 0o600
 
 
 def test_config_save_rejects_unknown_key(client, tmp_path, monkeypatch):

--- a/tests/test_config_overrides.py
+++ b/tests/test_config_overrides.py
@@ -63,3 +63,60 @@ def test_load_user_config_reads_valid_json(monkeypatch, tmp_path):
     good.write_text('{"secrets": {"use_AI": true}}', encoding="utf-8")
     monkeypatch.setattr(overrides, "USER_CONFIG_PATH", str(good))
     assert overrides.load_user_config() == {"secrets": {"use_AI": True}}
+
+
+# ---------------------------------------------------------------------------
+# The control panel derives its fields from config/*.py, and docs/config-*.md
+# describes the same settings in prose. Both used to be hand-synced and both
+# drifted: 24 settings had no panel field while the docs claimed 3, and the docs
+# named two settings that do not exist. These turn that drift into a red test.
+# ---------------------------------------------------------------------------
+import importlib
+import pathlib
+import re
+
+import config_schema
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+# Its default is None, which no form control can express - see docs/configuration.md.
+_NOT_IN_PANEL = {"llm_temperature"}
+
+
+def _config_keys():
+    '''Every setting name defined in config/*.py.'''
+    return {key for name in config_schema.MODULES
+            for key in vars(importlib.import_module("config." + name))
+            if not key.startswith("_")}
+
+
+def test_panel_has_a_field_for_every_setting():
+    fields = {field["key"] for field in config_schema.iter_fields()}
+    assert _config_keys() - fields == _NOT_IN_PANEL
+    assert fields - _config_keys() == set()      # and never invents one
+
+
+def test_docs_and_config_name_the_same_settings():
+    docs = "\n".join(page.read_text(encoding="utf-8")
+                     for page in sorted((_ROOT / "docs").glob("config-*.md")))
+    named = set(re.findall(r"`([a-z][a-z0-9]*(?:_[a-zA-Z0-9]+)+)`", docs))
+    keys = _config_keys()
+    invented = sorted(named - keys)
+    undocumented = sorted(keys - set(re.findall(r"`(\w+)`", docs)))
+    assert not invented, f"docs name settings config/*.py does not have: {invented}"
+    assert not undocumented, f"settings no docs page mentions: {undocumented}"
+
+
+def test_field_types_come_from_the_config_file():
+    '''The parser is the only thing standing between a config comment and the form.'''
+    fields = {field["key"]: field for field in config_schema.iter_fields()}
+    assert fields["require_visa"]["type"] == "select"          # trailing `# "Yes" or "No"`
+    assert fields["require_visa"]["options"] == ["Yes", "No"]
+    assert fields["on_site"]["type"] == "list"                 # `# (multiple select) ...`
+    assert fields["on_site"]["options"] == ["On-site", "Remote", "Hybrid"]
+    assert fields["companies"].get("options") is None          # dynamic: any value goes
+    assert fields["recent_employer"]["type"] == "text"         # its `Eg:` is not a vocabulary
+    assert fields["cover_letter"]["type"] == "textarea"        # a default with line breaks
+    assert fields["password"]["type"] == "password"
+    assert fields["click_gap"]["step"] == 1                    # a whole-number setting
+    assert "sponsorship" in fields["skip_non_sponsoring_jobs"]["help"]
+    assert "lakhs" in fields["desired_salary"]["help"]         # the triple-quoted note below

--- a/tests/test_driver_arch.py
+++ b/tests/test_driver_arch.py
@@ -12,6 +12,7 @@ No browser, no network: everything the shim touches outside the process is stubb
 License: MIT  (https://opensource.org/license/mit)
 '''
 
+import os
 import subprocess
 import sys
 from unittest import mock
@@ -19,16 +20,11 @@ from unittest import mock
 import pytest
 
 import undetected_chromedriver as uc
-import modules.helpers as helpers
 from selenium.webdriver.common.selenium_manager import SeleniumManager
 
+import modules.open_chrome as oc          # importing this must NOT open a browser
 
-# ---------------------------------------------------------------------------
-# modules/open_chrome.py opens a real browser at import time. Stub the four things
-# that reach outside the process, import it once, then every test works on the real
-# module. binary_paths raising also makes the import exercise the fallback path.
-# ---------------------------------------------------------------------------
-_chrome_kwargs = []
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 class _FakeChrome:
@@ -39,17 +35,35 @@ class _FakeChrome:
         pass
 
 
-with mock.patch.object(uc, "Chrome", _FakeChrome), \
-     mock.patch.object(helpers, "make_directories", lambda paths: None), \
-     mock.patch.object(helpers, "get_default_temp_profile", lambda: "/tmp/not-a-real-profile"), \
-     mock.patch.object(SeleniumManager, "binary_paths", side_effect=OSError("no selenium manager")):
-    import modules.open_chrome as oc
+_chrome_kwargs = []
 
 
-def test_import_time_launch_fell_back_to_ucs_own_download():
+def test_importing_the_module_starts_nothing(tmp_path):
+    '''The launch used to run at module scope, so `import runAiBot` opened Chrome.
+    A real check, not a mock: import it in a clean interpreter in an empty folder and
+    see that nothing createChromeSession() makes ever appears.'''
+    probe = ("import modules.open_chrome as oc\n"
+             "assert (oc.options, oc.driver, oc.actions, oc.wait) == (None, None, None, None)\n")
+    done = subprocess.run([sys.executable, "-c", probe], cwd=tmp_path, capture_output=True,
+                          text=True, timeout=300, env=dict(os.environ, PYTHONPATH=ROOT))
+    assert done.returncode == 0, done.stderr
+    # Only createChromeSession() makes these, and a driver download would land under ~/.
+    for evidence_of_a_launch in ("all excels", "all resumes", "logs/screenshots"):
+        assert not (tmp_path / evidence_of_a_launch).exists(), evidence_of_a_launch
+
+
+def test_launch_falls_back_to_ucs_own_download(monkeypatch):
     '''With Selenium Manager broken, the launch must still happen the old way.'''
-    assert _chrome_kwargs, "modules.open_chrome never constructed a driver"
+    _chrome_kwargs.clear()
+    monkeypatch.setattr(oc.uc, "Chrome", _FakeChrome)
+    monkeypatch.setattr(oc, "make_directories", lambda paths: None)
+    monkeypatch.setattr(oc, "get_default_temp_profile", lambda: "/tmp/not-a-real-profile")
+    monkeypatch.setattr(SeleniumManager, "binary_paths", mock.Mock(side_effect=OSError("no selenium manager")))
+
+    assert oc.start_browser()[1] is oc.driver          # returns what it publishes
+    assert _chrome_kwargs, "start_browser() never constructed a driver"
     assert "driver_executable_path" not in _chrome_kwargs[0]
+    monkeypatch.setattr(oc, "driver", None)            # leave the module as we found it
 
 
 def test_selenium_manager_failure_returns_none(monkeypatch):

--- a/tests/test_h1b_sponsorship.py
+++ b/tests/test_h1b_sponsorship.py
@@ -26,18 +26,13 @@ behaviour, not the user's own config/search.py.
 License: MIT  (https://opensource.org/license/mit)
 '''
 
-import sys
-import types
 
 import pytest
 
 
 @pytest.fixture(scope="module")
 def bot():
-    '''Import runAiBot with a stubbed browser session, so importing it never opens Chrome.'''
-    fake_chrome = types.ModuleType("modules.open_chrome")
-    fake_chrome.options = fake_chrome.driver = fake_chrome.actions = fake_chrome.wait = None
-    sys.modules["modules.open_chrome"] = fake_chrome
+    '''runAiBot. Importing it opens no browser: the launch lives in open_chrome.start_browser().'''
     import runAiBot
     return runAiBot
 

--- a/tests/test_question_matching.py
+++ b/tests/test_question_matching.py
@@ -31,10 +31,12 @@ from selenium.common.exceptions import NoSuchElementException
 
 @pytest.fixture(scope="module")
 def bot():
-    '''Import runAiBot with a stubbed browser session, so importing it never opens Chrome.'''
-    fake_chrome = types.ModuleType("modules.open_chrome")
-    fake_chrome.options = fake_chrome.driver = fake_chrome.actions = fake_chrome.wait = None
-    sys.modules["modules.open_chrome"] = fake_chrome
+    '''
+    Import runAiBot. No stub needed any more: modules/open_chrome.py no longer opens a
+    browser at import, it waits for start_browser(). The stub that used to live here was
+    worse than nothing - it lacked start_browser, so it built a runAiBot missing a name
+    the real module has, and the difference only showed up when another test file needed it.
+    '''
     import runAiBot
     return runAiBot
 

--- a/tests/test_question_matching.py
+++ b/tests/test_question_matching.py
@@ -542,11 +542,13 @@ class FakeTextInput(FakeElement):
     def __init__(self, value=""):
         super().__init__()
         self.value = value
+        self.cleared = False
 
     def get_attribute(self, name):
         return self.value if name == "value" else None
 
     def clear(self):
+        self.cleared = True
         self.value = ""
 
 
@@ -616,3 +618,73 @@ def test_an_unrecognised_dropdown_question_is_left_unanswered(bot, monkeypatch):
     assert select.selected == "Select an option"
     assert bot.unanswered_questions
     assert {answer for _, answer, kind, _ in questions_list if kind == "select"} == {"Select an option"}
+
+
+# --------------------------- a field-shaped rung vs a Yes/No question --------------
+def yes_no_text_question(bot, monkeypatch, question):
+    '''A text question, with the typeahead follow-up stubbed so a wrong answer to a
+    Yes/No question fails on the assertion rather than on `actions` being None.'''
+    monkeypatch.setattr(bot, "current_city", "Fremont")
+    monkeypatch.setattr(bot, "sleep", lambda *a: None)
+    monkeypatch.setattr(bot, "actions", FakeActions())
+    return text_question(bot, monkeypatch, question)
+
+
+def test_a_yes_no_text_question_is_never_answered_with_the_city(bot, monkeypatch):
+    '''The family, not the instance: a rung that names a FIELD ("city", "location",
+    "address", "name", "phone"...) matches on one word, so any Yes/No QUESTION that
+    merely mentions the field claimed it. There is no configured answer for this one,
+    so the honest outcome is unanswered - never the user's city.'''
+    question = "Are you able to relocate to this job's location?"
+    modal, field = yes_no_text_question(bot, monkeypatch, question)
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert field.value != "Fremont", f'typed the city into "{question}"'
+    assert field.value == "", f'answered "{field.value}"'
+    assert bot.unanswered_questions, "and it has to be reported so the job is skipped"
+    assert question in next(iter(bot.unanswered_questions))
+
+
+# --------------------------- the textarea branch -----------------------------------
+def textarea_question(bot, monkeypatch, label_text, value=""):
+    '''Builds a modal holding one textarea question; returns (modal, FakeTextInput).'''
+    monkeypatch.setattr(bot, "print_lg", lambda *a, **k: None)
+    monkeypatch.setattr(bot, "use_AI", False)
+    monkeypatch.setattr(bot, "human_type",
+                        lambda target, text: setattr(target, "value", target.value + (text or "")))
+    field = FakeTextInput(value)
+    question = FakeElement(children={".//textarea": field,
+                                     ".//label[@for]": FakeElement(text=label_text)})
+    return FakeElement(children={".//div[@data-test-form-element]": [question]}), field
+
+
+def test_an_unrecognised_textarea_question_is_left_unanswered(bot, monkeypatch):
+    '''The textarea twin of the radio and checkbox never-guess paths. `clear()` and
+    `human_type()` ran unconditionally, so a question with no configured answer was
+    still emptied and submitted blank.'''
+    question = "Describe a time you disagreed with your manager."
+    modal, field = textarea_question(bot, monkeypatch, question)
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert field.value == "", f'typed "{field.value}" into "{question}"'
+    assert not field.cleared, "an unanswered control must be left untouched, not emptied"
+    assert bot.unanswered_questions, "and it has to be reported so the job is skipped"
+    assert question in next(iter(bot.unanswered_questions))
+
+
+def test_a_pre_existing_textarea_answer_is_never_wiped(bot, monkeypatch):
+    '''`overwrite_previous_answers = False` skips the answer ladder, but `clear()` and
+    `human_type(text_area, "")` sat OUTSIDE that gate - so what the user wrote himself
+    was deleted and the box submitted empty.'''
+    monkeypatch.setattr(bot, "overwrite_previous_answers", False)
+    written = "I once disagreed with a rollout plan and we shipped a canary instead."
+    modal, field = textarea_question(bot, monkeypatch,
+                                     "Describe a time you disagreed with your manager.", written)
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert field.value == written, "the user's own answer was overwritten"
+    assert not field.cleared
+    assert not bot.unanswered_questions, "it is answered - it must not block the job"

--- a/tests/test_question_matching.py
+++ b/tests/test_question_matching.py
@@ -117,6 +117,29 @@ def test_label_has_matches_whole_words_only(bot):
     assert not bot.label_has("sexual orientation", 'sex')
 
 
+@pytest.mark.parametrize("label, expected", [
+    # Yes/No questions. A field-shaped rung must not claim any of these.
+    ("Are you comfortable commuting to this job's location?", True),
+    ("Do you have an active security clearance?", True),
+    ("Is your current address in the United States?", True),
+    ("Have you worked at Acme before?", True),
+    ("Would you consider a hybrid schedule?", True),
+    # NOT Yes/No questions - each one names a field and must keep its rung.
+    ("What city do you live in?", False),
+    ("Current location", False),
+    ("Location (City, State)", False),
+    ("Where are you located?", False),
+    ("How many years of experience do you have?", False),
+    ("Address", False),
+    ("Please describe your ideal role.", False),
+    ("Are you comfortable with a long commute", False),   # no "?" - not asked as a question
+    ("Isabella, confirm your street", False),             # "is" is not the word "Is"
+])
+def test_asks_yes_no_needs_both_halves(bot, label, expected):
+    assert bot.asks_yes_no(label) is expected
+    assert bot.asks_yes_no(label.lower()) is expected     # the call sites lower-case first
+
+
 def test_work_authorization_beats_location(bot):
     '''The live failure: "...United States?" was routed to the location branch.'''
     assert bot.work_authorization_answer(
@@ -688,3 +711,57 @@ def test_a_pre_existing_textarea_answer_is_never_wiped(bot, monkeypatch):
     assert field.value == written, "the user's own answer was overwritten"
     assert not field.cleared
     assert not bot.unanswered_questions, "it is answered - it must not block the job"
+
+
+
+
+@pytest.mark.parametrize("configured", ["Yes", "No"])
+def test_the_commuting_question_is_answered_from_config_not_the_city(bot, monkeypatch, configured):
+    '''Verbatim from a live form, and the reason `comfortable_commuting` exists: it
+    carries the whole word "location", so it was answered "Fremont".'''
+    monkeypatch.setattr(bot, "comfortable_commuting", configured)
+    question = "Are you comfortable commuting to this job's location?"
+    modal, field = yes_no_text_question(bot, monkeypatch, question)
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert field.value == configured, f'answered "{field.value}" to "{question}"'
+    assert not bot.unanswered_questions
+
+
+@pytest.mark.parametrize("options", [["Select an option", "Yes", "No"],
+                                     ["Select an option", "Yes", "No", "Fremont"]])
+def test_the_commuting_dropdown_is_answered_not_left_to_luck(bot, monkeypatch, options):
+    '''As a <select> it only survived because a city string cannot match a Yes/No option.
+    With the city ON OFFER it would have been picked.'''
+    monkeypatch.setattr(bot, "comfortable_commuting", "Yes")
+    monkeypatch.setattr(bot, "current_city", "Fremont")
+    modal, select = dropdown(bot, monkeypatch,
+                             "Are you comfortable commuting to this job's location?", options)
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert select.picked == "Yes", f'picked "{select.picked}"'
+
+
+def test_the_commuting_radio_is_answered(bot, monkeypatch):
+    monkeypatch.setattr(bot, "comfortable_commuting", "Yes")
+    modal, mouse, _ = radio_group(bot, monkeypatch,
+                                  "Are you comfortable commuting to this job's location?",
+                                  ["Yes", "No"])
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert mouse.clicked.text == "Yes"
+
+
+def test_a_real_location_field_still_gets_the_city(bot, monkeypatch):
+    '''Guard against over-correcting: only a Yes/No QUESTION is skipped, not a field.'''
+    monkeypatch.setattr(bot, "current_city", "Fremont")
+    monkeypatch.setattr(bot, "sleep", lambda *a: None)
+    monkeypatch.setattr(bot, "actions", FakeActions())
+    modal, field = text_question(bot, monkeypatch, "City")
+
+    bot.answer_questions(modal, set(), "Remote")
+
+    assert field.value == "Fremont"

--- a/tests/test_question_matching.py
+++ b/tests/test_question_matching.py
@@ -42,6 +42,7 @@ def bot():
 
 
 STATE = "Teststate"
+CITY = "Testville"   # never the author's real city: this file is tracked in a public repo
 CITIZENSHIP = "Non-citizen allowed to work for any employer"
 CITIZENSHIP_OPTIONS = ["Select an option", "U.S. Citizen/Permanent Resident",
                        "Non-citizen allowed to work for any employer", CITIZENSHIP,
@@ -649,7 +650,7 @@ def test_an_unrecognised_dropdown_question_is_left_unanswered(bot, monkeypatch):
 def yes_no_text_question(bot, monkeypatch, question):
     '''A text question, with the typeahead follow-up stubbed so a wrong answer to a
     Yes/No question fails on the assertion rather than on `actions` being None.'''
-    monkeypatch.setattr(bot, "current_city", "Fremont")
+    monkeypatch.setattr(bot, "current_city", "Testville")
     monkeypatch.setattr(bot, "sleep", lambda *a: None)
     monkeypatch.setattr(bot, "actions", FakeActions())
     return text_question(bot, monkeypatch, question)
@@ -665,7 +666,7 @@ def test_a_yes_no_text_question_is_never_answered_with_the_city(bot, monkeypatch
 
     bot.answer_questions(modal, set(), "Remote")
 
-    assert field.value != "Fremont", f'typed the city into "{question}"'
+    assert field.value != "Testville", f'typed the city into "{question}"'
     assert field.value == "", f'answered "{field.value}"'
     assert bot.unanswered_questions, "and it has to be reported so the job is skipped"
     assert question in next(iter(bot.unanswered_questions))
@@ -720,7 +721,7 @@ def test_a_pre_existing_textarea_answer_is_never_wiped(bot, monkeypatch):
 @pytest.mark.parametrize("configured", ["Yes", "No"])
 def test_the_commuting_question_is_answered_from_config_not_the_city(bot, monkeypatch, configured):
     '''Verbatim from a live form, and the reason `comfortable_commuting` exists: it
-    carries the whole word "location", so it was answered "Fremont".'''
+    carries the whole word "location", so it was answered "Testville".'''
     monkeypatch.setattr(bot, "comfortable_commuting", configured)
     question = "Are you comfortable commuting to this job's location?"
     modal, field = yes_no_text_question(bot, monkeypatch, question)
@@ -732,12 +733,12 @@ def test_the_commuting_question_is_answered_from_config_not_the_city(bot, monkey
 
 
 @pytest.mark.parametrize("options", [["Select an option", "Yes", "No"],
-                                     ["Select an option", "Yes", "No", "Fremont"]])
+                                     ["Select an option", "Yes", "No", "Testville"]])
 def test_the_commuting_dropdown_is_answered_not_left_to_luck(bot, monkeypatch, options):
     '''As a <select> it only survived because a city string cannot match a Yes/No option.
     With the city ON OFFER it would have been picked.'''
     monkeypatch.setattr(bot, "comfortable_commuting", "Yes")
-    monkeypatch.setattr(bot, "current_city", "Fremont")
+    monkeypatch.setattr(bot, "current_city", "Testville")
     modal, select = dropdown(bot, monkeypatch,
                              "Are you comfortable commuting to this job's location?", options)
 
@@ -759,11 +760,11 @@ def test_the_commuting_radio_is_answered(bot, monkeypatch):
 
 def test_a_real_location_field_still_gets_the_city(bot, monkeypatch):
     '''Guard against over-correcting: only a Yes/No QUESTION is skipped, not a field.'''
-    monkeypatch.setattr(bot, "current_city", "Fremont")
+    monkeypatch.setattr(bot, "current_city", "Testville")
     monkeypatch.setattr(bot, "sleep", lambda *a: None)
     monkeypatch.setattr(bot, "actions", FakeActions())
     modal, field = text_question(bot, monkeypatch, "City")
 
     bot.answer_questions(modal, set(), "Remote")
 
-    assert field.value == "Fremont"
+    assert field.value == "Testville"

--- a/tests/test_runaibot_fixes.py
+++ b/tests/test_runaibot_fixes.py
@@ -9,8 +9,6 @@ License: MIT  (https://opensource.org/license/mit)
 '''
 
 import os
-import sys
-import types
 
 import pytest
 from selenium.common.exceptions import NoSuchElementException
@@ -18,10 +16,7 @@ from selenium.common.exceptions import NoSuchElementException
 
 @pytest.fixture(scope="module")
 def bot():
-    '''Import runAiBot with a stubbed browser session, so importing it never opens Chrome.'''
-    fake_chrome = types.ModuleType("modules.open_chrome")
-    fake_chrome.options = fake_chrome.driver = fake_chrome.actions = fake_chrome.wait = None
-    sys.modules["modules.open_chrome"] = fake_chrome
+    '''runAiBot. Importing it opens no browser: the launch lives in open_chrome.start_browser().'''
     import runAiBot
     return runAiBot
 

--- a/tests/test_runaibot_fixes.py
+++ b/tests/test_runaibot_fixes.py
@@ -64,7 +64,7 @@ class FakeElement:
 def test_textarea_question_without_an_earlier_text_input(bot, monkeypatch):
     '''A cover-letter textarea used to read do_actions, which only the text branch set.'''
     typed = []
-    monkeypatch.setattr(bot, "human_type", lambda target, text: typed.append((target, text)), raising=False)
+    monkeypatch.setattr(bot, "human_type", lambda target, text: typed.append((target, text)))
     monkeypatch.setattr(bot, "print_lg", lambda *a, **k: None)
 
     textarea = FakeElement()
@@ -83,7 +83,7 @@ def test_textarea_question_without_an_earlier_text_input(bot, monkeypatch):
 
 def test_text_question_is_typed_through_human_type(bot, monkeypatch):
     typed = []
-    monkeypatch.setattr(bot, "human_type", lambda target, text: typed.append((target, text)), raising=False)
+    monkeypatch.setattr(bot, "human_type", lambda target, text: typed.append((target, text)))
     monkeypatch.setattr(bot, "print_lg", lambda *a, **k: None)
 
     text_input = FakeElement()

--- a/tests/test_selectors_groundtruth.py
+++ b/tests/test_selectors_groundtruth.py
@@ -11,6 +11,7 @@ Stdlib only - `html.parser`. lxml and bs4 are not dependencies of this project.
 License: MIT  (https://opensource.org/license/mit)
 '''
 
+import glob
 import inspect
 import os
 import sys
@@ -123,15 +124,20 @@ def bot():
 @pytest.fixture(scope="module")
 def sources():
     '''
-    Source of the two selector-carrying modules with `#` comments stripped, so a dead
-    selector *named in a comment* (this file's own history is full of them) doesn't
-    fail the "it never came back" tests. String literals are kept - that is where
-    locators live.
+    Every `.py` file in the project with `#` comments stripped, so a dead selector
+    *named in a comment* (this file's own history is full of them) doesn't fail the
+    "it never came back" tests. String literals are kept - that is where locators live.
+
+    This used to be a literal list of the two modules that carry selectors today. Move
+    one locator into a new module and the six `not in` tests below keep passing while
+    checking nothing, so sweep the repo instead of naming files.
     '''
     root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     out = {}
-    for rel in ("runAiBot.py", os.path.join("modules", "clickers_and_finders.py")):
-        with open(os.path.join(root, rel), encoding="utf-8") as f:
+    for path in sorted(glob.glob(os.path.join(root, "**", "*.py"), recursive=True)):
+        rel = os.path.relpath(path, root)
+        if {".venv", "tests", "__pycache__"} & set(rel.split(os.sep)): continue
+        with open(path, encoding="utf-8") as f:
             # untokenize() rebuilds from the original positions, so the remaining code
             # keeps its exact spelling - the "did it come back" checks stay meaningful.
             kept = [t for t in tokenize.generate_tokens(f.readline) if t.type != tokenize.COMMENT]
@@ -143,6 +149,16 @@ def test_source_fixture_is_not_vacuous(sources):
     '''Guard for every `not in sources[...]` assertion below: code text must survive.'''
     assert "By.CSS_SELECTOR, login_email_css" in sources["runAiBot.py"]
     assert "def pick_first_displayed" in sources[os.path.join("modules", "clickers_and_finders.py")]
+    # Those `not in` tests sweep every file, so an empty sweep - or one that stopped
+    # reaching the file a locator lives in - passes them all. Pin the LIVE replacement
+    # for each dead locator: a dead one and its replacement move together, so a missing
+    # replacement means the sweep changed, not that the bug stayed fixed.
+    everything = "".join(sources.values())
+    for live in ("By.CSS_SELECTOR, login_email_css",     # replaced By.ID, "username"
+                 "data-occludable-job-id",               # replaced job-card-container__*
+                 "jobs-apply-button-id",                 # the anchor, not artdeco-button--3
+                 "data-test-form-element"):              # replaced jobs-easy-apply-form-element
+        assert live in everything, live
 
 
 # =================================================================================

--- a/tests/test_selectors_groundtruth.py
+++ b/tests/test_selectors_groundtruth.py
@@ -14,9 +14,7 @@ License: MIT  (https://opensource.org/license/mit)
 import glob
 import inspect
 import os
-import sys
 import tokenize
-import types
 from html.parser import HTMLParser
 
 import pytest
@@ -113,10 +111,7 @@ def attr(name, value=None):
 
 @pytest.fixture(scope="module")
 def bot():
-    '''runAiBot with a stubbed browser session, so importing it never opens Chrome.'''
-    fake_chrome = types.ModuleType("modules.open_chrome")
-    fake_chrome.options = fake_chrome.driver = fake_chrome.actions = fake_chrome.wait = None
-    sys.modules["modules.open_chrome"] = fake_chrome
+    '''runAiBot. Importing it opens no browser: the launch lives in open_chrome.start_browser().'''
     import runAiBot
     return runAiBot
 

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -1,0 +1,118 @@
+'''
+The bot has to actually open a browser.
+
+`modules/open_chrome.py` used to call `createChromeSession()` at module scope, so
+importing `runAiBot` launched Chrome. That was removed so a bad config no longer costs
+you a browser window and a driver download before anything validates it - but it means
+`main()` now has to open the browser itself, and `runAiBot`'s star-imported
+`driver`/`options`/`actions`/`wait` are separate bindings that stay `None` until it does.
+
+Miss that call and every `driver.*` in `main()` raises `AttributeError` on `None`, which
+`main()`'s own `except Exception` swallows into a log line and an alert. The bot appears
+to run and applies to nothing. The whole suite stayed green while that was true, because
+nothing else here ever enters `main()`.
+'''
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture
+def bot(monkeypatch):
+    import runAiBot
+    # main()'s finally block reads the run counters; keep this test from depending on
+    # whatever another test left behind in them.
+    for counter in ("easy_applied_count", "external_jobs_count", "failed_count", "skip_count"):
+        monkeypatch.setattr(runAiBot, counter, 0, raising=True)
+    return runAiBot
+
+
+def _stub_everything_but_the_browser(bot, monkeypatch, driver):
+    '''Neutralise every step of main() except the one under test.'''
+    monkeypatch.setattr(bot, "validate_config", lambda: None)
+    monkeypatch.setattr(bot, "is_logged_in_LN", lambda: True)
+    monkeypatch.setattr(bot, "login_LN", lambda: None)
+    monkeypatch.setattr(bot, "run", lambda total: total)
+    monkeypatch.setattr(bot, "use_AI", False)
+    monkeypatch.setattr(bot, "run_non_stop", False)
+    monkeypatch.setattr(bot, "alternate_sortby", False)
+    monkeypatch.setattr(bot, "cycle_date_posted", False)
+    monkeypatch.setattr(bot, "close_tabs", False)
+    monkeypatch.setattr(bot, "pyautogui", mock.MagicMock())
+    monkeypatch.setattr(bot.os.path, "exists", lambda _p: True)
+    monkeypatch.setattr(bot, "start_browser", lambda: ("opts", driver, "actions", "wait"))
+
+
+def _fake_driver():
+    driver = mock.MagicMock()
+    driver.window_handles = ["window-1"]
+    driver.current_window_handle = "window-1"
+    return driver
+
+
+def test_main_opens_a_browser_and_binds_it(bot, monkeypatch):
+    '''The regression this file exists for.'''
+    driver = _fake_driver()
+    _stub_everything_but_the_browser(bot, monkeypatch, driver)
+    monkeypatch.setattr(bot, "driver", None, raising=True)
+
+    bot.main()
+
+    assert bot.driver is driver, (
+        "main() did not rebind the module-level driver - open_chrome no longer opens "
+        "one at import, so every driver.* call in main() is an AttributeError on None"
+    )
+
+
+def test_main_does_not_swallow_a_startup_failure(bot, monkeypatch):
+    '''
+    main() catches bare `Exception` and turns it into a log line, so a broken startup
+    looks exactly like a successful run that found no jobs. Assert nothing was caught.
+    '''
+    driver = _fake_driver()
+    _stub_everything_but_the_browser(bot, monkeypatch, driver)
+    monkeypatch.setattr(bot, "driver", None, raising=True)
+    swallowed = []
+    monkeypatch.setattr(bot, "critical_error_log", lambda *a, **k: swallowed.append(a))
+
+    bot.main()
+
+    assert not swallowed, f"main() swallowed a startup error: {swallowed}"
+
+
+def test_the_browser_opens_only_after_the_config_validates(bot, monkeypatch):
+    '''
+    Ordering is the point of the change: a typo in config must not cost a Chrome window
+    and a driver download. If validate_config() raises, no browser may be opened.
+    '''
+    order = []
+    driver = _fake_driver()
+    _stub_everything_but_the_browser(bot, monkeypatch, driver)
+
+    def exploding_validate():
+        order.append("validate")
+        raise ValueError("bad config")
+
+    monkeypatch.setattr(bot, "validate_config", exploding_validate)
+    monkeypatch.setattr(bot, "start_browser", lambda: order.append("browser") or ("o", driver, "a", "w"))
+    monkeypatch.setattr(bot, "critical_error_log", lambda *a, **k: None)
+
+    bot.main()
+
+    assert order == ["validate"], f"browser opened despite an invalid config: {order}"
+
+
+def test_importing_runaibot_opens_no_browser():
+    '''
+    The property the whole change is for. Importing the bot must not touch a browser -
+    this is what let four separate test files stop injecting a fake open_chrome module.
+    '''
+    import runAiBot  # already imported by now; assert the module-level state, not the import
+    assert "modules.open_chrome" in sys.modules
+    oc = sys.modules["modules.open_chrome"]
+    if isinstance(oc, types.ModuleType) and hasattr(oc, "start_browser"):
+        # A real (not stubbed) open_chrome must expose start_browser and must not have
+        # created a session as a side effect of being imported.
+        assert callable(oc.start_browser)


### PR DESCRIPTION
242 → 348 tests. Four live defects fixed, each pinned by a test that was mutation-checked (reverted the fix, watched it go red, restored it).

## Four defects that were live on real applications

1. **Textarea wiped the control it refused to answer.** `clear()` + `human_type()` sat outside the `if not prev_answer or overwrite_previous_answers:` gate, so a textarea the user had already filled in was emptied even with overwriting off — and an unrecognised question, which answers `""`, was submitted blank. Textarea was also the only control type with zero never-guess coverage.

2. **Text did the same inside its gate.** It ran with `answer == ""`, so with `overwrite_previous_answers` on it wiped LinkedIn's own prefill of the email, phone or city box and submitted it blank. The comment above it claimed it left LinkedIn's value in place.

3. **A Yes/No question claimed a field rung.** Every field rung matches on one word, so "Are you comfortable commuting to this job's location?" carried the whole word `location` and got the user's city typed into a Yes/No box. One `asks_yes_no()` predicate fixes the whole family, including "Do you have 5 years of experience?" answering with total years and "Do you have a LinkedIn profile?" answering with the URL. Adds a `comfortable_commuting` setting so the question is answered rather than skipped.

4. **The bot stopped opening a browser.** Removing the import-time Chrome launch left nothing calling `start_browser()`, so `driver` was `None` and every `driver.*` in `main()` raised `AttributeError` — which `main()`'s own `except Exception` swallowed into a log line. It would have reported a clean run and applied to nothing. 339 tests were green through it; `tests/test_startup.py` now pins it.

The never-guess invariant is now 5 of 5 control types, with tests.

## Security

`GET /api/config` returned the secrets section — LinkedIn password and API key — in cleartext, with no auth, no CSRF check, and a wildcard `Access-Control-Allow-Origin` from a bare `CORS(app)`. The POST response leaked the freshly-saved cleartext too. Binding to 127.0.0.1 stops other hosts, not a page open in the user's own browser.

Fixed by deleting CORS entirely (a same-origin app never needed it, and `flask-cors` is dropped), redacting both responses behind a sentinel that a round-trip cannot blank, and `chmod 0600` on `user_config.json` — which was landing 0644 holding the password, legal name, phone, street and ZIP.

## Configuration: three hand-synced sources → one

`config/*.py` declared 95 settings; `config_schema.py` covered 71. **24 were invisible to the control panel** (the docs claimed 3) and reverted to shipped defaults on every `git pull`, because `_freeze_config` only pinned what the old schema knew about — into a stash that is deliberately never popped and never mentioned in the success message.

The schema is now derived from `config/*.py` with stdlib `ast`, so type, legal values and help text exist once, in the file the user edits. Schema/validator contradictions that let the panel save a config the next run refuses to start on are resolved, and POST rejects any value outside a field's derived options. A docs-drift test found two settings documented that do not exist and two that exist undocumented.

## Local-model answer layer

A tiered path for form questions, aimed at a small local model (Qwen3.5-4B class) over an OpenAI-compatible endpoint. Config ladder stays tier 0 and remains the common case; the model is reachable only where the ladder came back empty.

- **AI proposes, the deterministic validator disposes.** An AI answer for a select or radio must still pass `match_answer_to_option` against the real option list — including on cache hits and hand-edited answers — or the control is left untouched.
- Eligibility filters stay deterministic and authoritative: `skip = deterministic or ai`, never `and`.
- Constrained decoding via `response_format: json_schema` rather than asking for JSON politely; static prompt prefix first so the prefix cache holds; `enable_thinking: false`; no retries.
- A refused connection marks the server down for the run — 50 questions against a dead endpoint cost one attempt and 12ms.
- Degrades to no-answer on every failure mode tested (down, timeout, HTTP 500, prose instead of JSON, wrong JSON type, empty content, no choices) and never raises into the apply loop.

**Unanswered questions are now recorded to a hand-editable JSON file** with their type and options, so answering one teaches the bot permanently instead of blocking the same job on every future run.

Everything AI is verified against stubs. No live model call has been made.

## Housekeeping

`open_chrome` no longer launches Chrome as an import side effect (import is 0.21s and spawns nothing), which let three of four `sys.modules` browser fakes be deleted — they lacked `start_browser` and made the suite order-dependent. Also deletes `multi_sel`, `text_input_by_ID`, the unreachable `select_option` graph node that returned an unvalidated model string straight into a form field, and 11 stale hand-maintained version docstrings; `VERSION` is the only thing read. Replaces the unfilled `<PATREON_LINK>` placeholder.